### PR TITLE
Use prefetcher for level merge

### DIFF
--- a/src/blob_gc_job.cc
+++ b/src/blob_gc_job.cc
@@ -520,12 +520,20 @@ Status BlobGCJob::InstallOutputBlobFiles() {
       to_delete_files.append(std::to_string(builder.first->GetNumber()));
       handles.emplace_back(std::move(builder.first));
     }
-    ROCKS_LOG_BUFFER(
-        log_buffer_,
-        "[%s] InstallOutputBlobFiles failed. Delete GC output files: %s",
-        blob_gc_->column_family_handle()->GetName().c_str(),
-        to_delete_files.c_str());
-    s = blob_file_manager_->BatchDeleteFiles(handles);
+    ROCKS_LOG_BUFFER(log_buffer_,
+                     "[%s] InstallOutputBlobFiles failed. Delete GC output "
+                     "files: %s",
+                     blob_gc_->column_family_handle()->GetName().c_str(),
+                     to_delete_files.c_str());
+    // Do not set status `s` here, cause it may override the non-okay-status of
+    // `s` so that in the outer funcation it will rewrite blob indexes to LSM by
+    // mistake.
+    Status status = blob_file_manager_->BatchDeleteFiles(handles);
+    if (!status.ok()) {
+      ROCKS_LOG_WARN(db_options_.info_log,
+                     "Delete GC output files[%s] failed: %s",
+                     to_delete_files.c_str(), status.ToString().c_str());
+    }
   }
   return s;
 }

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -97,6 +97,11 @@ void TitanTableBuilder::Add(const Slice& key, const Slice& value) {
           base_builder_->Add(index_key, index_value);
           return;
         }
+      } else {
+        ++error_read_cnt_;
+        ROCKS_LOG_DEBUG(db_options_.info_log,
+                        "Read file %" PRIu64 " error during level merge: %s",
+                        index.file_number, get_status.ToString().c_str());
       }
     }
     base_builder_->Add(key, value);
@@ -194,6 +199,11 @@ Status TitanTableBuilder::Finish() {
                     status_.ToString().c_str());
   }
   UpdateInternalOpStats();
+  if (error_read_cnt_ > 0) {
+    ROCKS_LOG_ERROR(db_options_.info_log,
+                    "Read file error %" PRIu64 " times during level merge",
+                    error_read_cnt_);
+  }
   return status();
 }
 

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -83,6 +83,8 @@ void TitanTableBuilder::Add(const Slice& key, const Slice& value) {
       PinnableSlice buffer;
       Status get_status = GetBlobRecord(index, &record, &buffer);
 
+      // If not ok, write original blob index as compaction output without
+      // doing level merge.
       if (get_status.ok()) {
         std::string index_value;
         AddBlob(ikey.user_key, record.value, &index_value);

--- a/src/table_builder.h
+++ b/src/table_builder.h
@@ -88,6 +88,7 @@ class TitanTableBuilder : public TableBuilder {
   uint64_t bytes_written_ = 0;
   uint64_t io_bytes_read_ = 0;
   uint64_t io_bytes_written_ = 0;
+  uint64_t error_read_cnt_ = 0;
 };
 
 }  // namespace titandb

--- a/src/table_builder.h
+++ b/src/table_builder.h
@@ -69,6 +69,8 @@ class TitanTableBuilder : public TableBuilder {
   std::vector<
       std::pair<std::shared_ptr<BlobFileMeta>, std::unique_ptr<BlobFileHandle>>>
       finished_blobs_;
+  std::unordered_map<uint64_t, std::unique_ptr<BlobFilePrefetcher>>
+      merging_blobs_;
   TitanStats* stats_;
 
   // target level in LSM-Tree for generated SSTs and blob files

--- a/src/table_builder.h
+++ b/src/table_builder.h
@@ -57,6 +57,8 @@ class TitanTableBuilder : public TableBuilder {
 
   void UpdateInternalOpStats();
 
+  Status GetBlobRecord(const BlobIndex& index, BlobRecord* record);
+
   Status status_;
   uint32_t cf_id_;
   TitanDBOptions db_options_;
@@ -70,7 +72,7 @@ class TitanTableBuilder : public TableBuilder {
       std::pair<std::shared_ptr<BlobFileMeta>, std::unique_ptr<BlobFileHandle>>>
       finished_blobs_;
   std::unordered_map<uint64_t, std::unique_ptr<BlobFilePrefetcher>>
-      merging_blobs_;
+      input_file_prefetchers_;
   TitanStats* stats_;
 
   // target level in LSM-Tree for generated SSTs and blob files


### PR DESCRIPTION
since level merge will read blob files sequentially, we should use prefetcher to accelerate merging.

experiment result:

Load 300GB (average value size 1KB) on Huawei NVME device, time to read blob file reduced about 50%.