### PR TITLE
Sync titan directory when adding blob files

### DIFF
--- a/src/blob_file_iterator_test.cc
+++ b/src/blob_file_iterator_test.cc
@@ -4,6 +4,7 @@
 
 #include "file/filename.h"
 #include "test_util/testharness.h"
+#include "util/random.h"
 
 #include "blob_file_builder.h"
 #include "blob_file_cache.h"

--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -74,6 +74,10 @@ class TitanDBImpl::FileManager : public BlobFileManager {
                      Slice(file.first->largest_key()).ToString(true).c_str());
       edit.AddBlobFile(file.first);
     }
+    s = db_->directory_->Fsync();
+    if (!s.ok()) {
+      return s;
+    }
 
     {
       MutexLock l(&db_->mutex_);
@@ -229,6 +233,10 @@ Status TitanDBImpl::OpenImpl(const std::vector<TitanCFDescriptor>& descs,
     }
   }
   s = env_->CreateDirIfMissing(dirname_);
+  if (!s.ok()) {
+    return s;
+  }
+  s = env_->NewDirectory(dirname_, &directory_);
   if (!s.ok()) {
     return s;
   }

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -250,6 +250,7 @@ class TitanDBImpl : public TitanDB {
   EnvOptions env_options_;
   DBImpl* db_impl_;
   TitanDBOptions db_options_;
+  std::unique_ptr<Directory> directory_;
 
   std::atomic<bool> initialized_{false};
 


### PR DESCRIPTION
Summary:
When adding new blob file, titan directory need to be fsync, otherwise files can be lost after power outage.

Test Plan:
run `strace -yfe fsync ./titan_titan_db_test --gtest_filter=*.Snapshot` and see titan directory being fsync-ed in the output.

Signed-off-by: Yi Wu <yiwu@pingcap.com>