### PR TITLE
Fix build on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,12 +105,12 @@ if (WITH_TITAN_TESTS AND (NOT CMAKE_BUILD_TYPE STREQUAL "Release"))
         rocksdb
         testutillib
         gtest)
-        
+
   foreach(test ${TESTS})
     add_executable(titan_${test} src/${test}.cc $<TARGET_OBJECTS:testharness>)
       target_link_libraries(titan_${test} ${TEST_LIBS})
       add_test(titan_${test} titan_${test})
-  endforeach(test ${TESTS})  
+  endforeach(test ${TESTS})
 endif()
 
 if (WITH_TITAN_TOOLS)
@@ -138,3 +138,16 @@ if (WITH_TITAN_TOOLS)
   target_include_directories(titandb_bench PRIVATE ${gflags_INCLUDE_DIR})
   target_link_libraries(titandb_bench ${TOOLS_LIBS})
 endif()
+
+# Installation - copy lib/ and include/
+
+include(GNUInstallDirs)
+install(DIRECTORY include/titan
+  COMPONENT devel
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)
+install(TARGETS titan
+  COMPONENT devel
+  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)

--- a/src/blob_file_set.h
+++ b/src/blob_file_set.h
@@ -9,7 +9,7 @@
 #include "blob_storage.h"
 #include "db/log_reader.h"
 #include "db/log_writer.h"
-#include "port/port_posix.h"
+#include "port/port.h"
 #include "rocksdb/options.h"
 #include "rocksdb/status.h"
 #include "titan/options.h"

--- a/src/blob_storage.cc
+++ b/src/blob_storage.cc
@@ -150,8 +150,6 @@ void BlobStorage::GetObsoleteFiles(std::vector<std::string>* obsolete_files,
                                    SequenceNumber oldest_sequence) {
   MutexLock l(&mutex_);
 
-  uint32_t file_dropped = 0;
-  uint64_t file_dropped_size = 0;
   for (auto it = obsolete_files_.begin(); it != obsolete_files_.end();) {
     auto& file_number = it->first;
     auto& obsolete_sequence = it->second;


### PR DESCRIPTION
1. use `#include "port/port.h"` instead of `#include "port/port_posix.h"`
2. added an "install" target for CMake to workaround alexcrichton/cmake-rs#18
3. MSVC reported 2 warnings in Titan (and tons of warnings in RocksDB), and these are fixed.