### PR TITLE
Sync titan directory when adding blob files (#136)

### DIFF
--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -71,6 +71,10 @@ class TitanDBImpl::FileManager : public BlobFileManager {
                      file.first->file_number());
       edit.AddBlobFile(file.first);
     }
+    s = db_->directory_->Fsync();
+    if (!s.ok()) {
+      return s;
+    }
 
     {
       MutexLock l(&db_->mutex_);
@@ -177,7 +181,13 @@ Status TitanDBImpl::Open(const std::vector<TitanCFDescriptor>& descs,
     if (!s.ok()) return s;
   }
   s = env_->CreateDirIfMissing(dirname_);
-  if (!s.ok()) return s;
+  if (!s.ok()) {
+    return s;
+  }
+  s = env_->NewDirectory(dirname_, &directory_);
+  if (!s.ok()) {
+    return s;
+  }
   s = env_->LockFile(LockFileName(dirname_), &lock_);
   if (!s.ok()) return s;
 

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -243,6 +243,8 @@ class TitanDBImpl : public TitanDB {
   EnvOptions env_options_;
   DBImpl* db_impl_;
   TitanDBOptions db_options_;
+  std::unique_ptr<Directory> directory_;
+
   // Turn DB into read-only if background error happened
   Status bg_error_;
   std::atomic_bool has_bg_error_{false};


### PR DESCRIPTION
Summary:
When adding new blob file, titan directory need to be fsync, otherwise files can be lost after power outage.

Test Plan:
run `strace -yfe fsync ./titan_titan_db_test --gtest_filter=*.Snapshot` and see titan directory being fsync-ed in the output.

Signed-off-by: Yi Wu <yiwu@pingcap.com>