### PR TITLE
fix warn caused by uninitialized gc_merge_rewrite

### DIFF
--- a/src/db_impl_gc.cc
+++ b/src/db_impl_gc.cc
@@ -164,7 +164,7 @@ Status TitanDBImpl::BackgroundGC(LogBuffer* log_buffer,
   StopWatch gc_sw(env_, stats_.get(), BLOB_DB_GC_MICROS);
 
   std::unique_ptr<BlobGC> blob_gc;
-  bool gc_merge_rewrite;
+  bool gc_merge_rewrite = false;
   std::unique_ptr<ColumnFamilyHandle> cfh;
   Status s;
 


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

Fix warn when titan is compiled with gcc 5.5.0
```
/home/pingcap/.cargo/git/checkouts/rust-rocksdb-e0eeb217423298aa/0e1a085/librocksdb_sys/libtitan_sys/titan/src/db_impl_gc.cc: In member function ‘rocksdb::Status rocksdb::titandb::TitanDBImpl::BackgroundGC(rocksdb::LogBuffer*, uint32_t)’:
/home/pingcap/.cargo/git/checkouts/rust-rocksdb-e0eeb217423298aa/0e1a085/librocksdb_sys/libtitan_sys/titan/src/db_impl_gc.cc:205:55: error: ‘gc_merge_rewrite’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
                           &shuting_down_, stats_.get());
```