### PR TITLE
exclude metadata size from file size for discardable ratio

### DIFF
--- a/src/blob_format.cc
+++ b/src/blob_format.cc
@@ -290,8 +290,9 @@ TitanInternalStats::StatsType BlobFileMeta::GetDiscardableRatioLevel() const {
              (ratio - 1.0) < std::numeric_limits<double>::epsilon()) {
     type = TitanInternalStats::NUM_DISCARDABLE_RATIO_LE100;
   } else {
-    fprintf(stderr, "invalid discardable ratio");
-    abort();
+    fprintf(stderr, "invalid discardable ratio  %lf for blob file %" PRIu64,
+            ratio, this->file_number_);
+    type = TitanInternalStats::NUM_DISCARDABLE_RATIO_LE100;
   }
   return type;
 }

--- a/src/blob_format.h
+++ b/src/blob_format.h
@@ -259,8 +259,9 @@ class BlobFileMeta {
     if (file_size_ == 0) {
       return 0;
     }
-    // TODO: Exclude metadata size from file size.
-    return 1 - (static_cast<double>(live_data_size_) / file_size_);
+    // TODO: Exclude meta blocks from file size
+    return 1 - (static_cast<double>(live_data_size_) /
+                (file_size_ - kBlobMaxHeaderSize - kBlobFooterSize));
   }
   TitanInternalStats::StatsType GetDiscardableRatioLevel() const;
 

--- a/src/blob_gc_picker_test.cc
+++ b/src/blob_gc_picker_test.cc
@@ -29,11 +29,12 @@ class BlobGCPickerTest : public testing::Test {
         new BasicBlobGCPicker(titan_db_options, titan_cf_options, nullptr));
   }
 
-  void AddBlobFile(uint64_t file_number, uint64_t file_size,
+  void AddBlobFile(uint64_t file_number, uint64_t data_size,
                    uint64_t discardable_size, bool being_gc = false) {
-    auto f =
-        std::make_shared<BlobFileMeta>(file_number, file_size, 0, 0, "", "");
-    f->set_live_data_size(file_size - discardable_size);
+    auto f = std::make_shared<BlobFileMeta>(
+        file_number, data_size + kBlobMaxHeaderSize + kBlobFooterSize, 0, 0, "",
+        "");
+    f->set_live_data_size(data_size - discardable_size);
     f->FileStateTransit(BlobFileMeta::FileEvent::kDbRestart);
     if (being_gc) {
       f->FileStateTransit(BlobFileMeta::FileEvent::kGCBegin);


### PR DESCRIPTION
exclude metadata size from file size, otherwise discardable ratio would be wrong when the blob file is small.