### PR TITLE
Add interface MultiBatchWrite for TitanDB

### DIFF
--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -554,7 +554,6 @@ Status TitanDBImpl::MultiBatchWrite(const WriteOptions& options,
                       : db_->MultiBatchWrite(options, std::move(updates));
 }
 
-
 Status TitanDBImpl::Delete(const rocksdb::WriteOptions& options,
                            rocksdb::ColumnFamilyHandle* column_family,
                            const rocksdb::Slice& key) {

--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -550,7 +550,8 @@ Status TitanDBImpl::Write(const rocksdb::WriteOptions& options,
 
 Status TitanDBImpl::MultiBatchWrite(const WriteOptions& options,
                                     std::vector<WriteBatch*>&& updates) {
-  return HasBGError() ? GetBGError() : db_->MultiBatchWrite(options, std::move(updates));
+  return HasBGError() ? GetBGError()
+                      : db_->MultiBatchWrite(options, std::move(updates));
 }
 
 

--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -548,6 +548,12 @@ Status TitanDBImpl::Write(const rocksdb::WriteOptions& options,
   return HasBGError() ? GetBGError() : db_->Write(options, updates);
 }
 
+Status TitanDBImpl::MultiBatchWrite(const WriteOptions& options,
+                                    std::vector<WriteBatch*>&& updates) {
+  return HasBGError() ? GetBGError() : db_->MultiBatchWrite(options, std::move(updates));
+}
+
+
 Status TitanDBImpl::Delete(const rocksdb::WriteOptions& options,
                            rocksdb::ColumnFamilyHandle* column_family,
                            const rocksdb::Slice& key) {

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -66,7 +66,6 @@ class TitanDBImpl : public TitanDB {
   Status MultiBatchWrite(const WriteOptions& options,
                          std::vector<WriteBatch*>&& updates) override;
 
-
   using TitanDB::Delete;
   Status Delete(const WriteOptions& options, ColumnFamilyHandle* column_family,
                 const Slice& key) override;

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -62,6 +62,11 @@ class TitanDBImpl : public TitanDB {
   using TitanDB::Write;
   Status Write(const WriteOptions& options, WriteBatch* updates) override;
 
+  using TitanDB::MultiBatchWrite;
+  Status MultiBatchWrite(const WriteOptions& options,
+                         std::vector<WriteBatch*>&& updates) override;
+
+
   using TitanDB::Delete;
   Status Delete(const WriteOptions& options, ColumnFamilyHandle* column_family,
                 const Slice& key) override;


### PR DESCRIPTION
This is a new interface which is added to RocksDB recently and TiKV will call it if `enable_multi_thread_write` of `DBOptions` is true. So Titan must implement it by self.