### PR TITLE
Fix discardable ratio count stat

### DIFF
--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -1233,7 +1233,9 @@ void TitanDBImpl::OnCompactionCompleted(
           assert(false);
           delta = 0;
         }
+        SubStats(stats_.get(), compaction_job_info.cf_id, file->GetDiscardableRatioLevel(), 1);
         file->set_live_data_size(static_cast<uint64_t>(delta));
+        AddStats(stats_.get(), compaction_job_info.cf_id, file->GetDiscardableRatioLevel(), 1);
         file->FileStateTransit(BlobFileMeta::FileEvent::kCompactionCompleted);
         to_merge_candidates.push_back(file);
         ROCKS_LOG_INFO(

--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -1233,9 +1233,11 @@ void TitanDBImpl::OnCompactionCompleted(
           assert(false);
           delta = 0;
         }
-        SubStats(stats_.get(), compaction_job_info.cf_id, file->GetDiscardableRatioLevel(), 1);
+        SubStats(stats_.get(), compaction_job_info.cf_id,
+                 file->GetDiscardableRatioLevel(), 1);
         file->set_live_data_size(static_cast<uint64_t>(delta));
-        AddStats(stats_.get(), compaction_job_info.cf_id, file->GetDiscardableRatioLevel(), 1);
+        AddStats(stats_.get(), compaction_job_info.cf_id,
+                 file->GetDiscardableRatioLevel(), 1);
         file->FileStateTransit(BlobFileMeta::FileEvent::kCompactionCompleted);
         to_merge_candidates.push_back(file);
         ROCKS_LOG_INFO(

--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -1137,7 +1137,12 @@ void TitanDBImpl::OnFlushCompleted(const FlushJobInfo& flush_job_info) {
         assert(false);
         delta = 0;
       }
+      
+      // the metrics is counted in the table builder when flushing,
+      // so update it when updateing the live data size.
+      SubStats(stats_.get(), flush_job_info.cf_id, file->GetDiscardableRatioLevel(), 1);
       file->set_live_data_size(static_cast<uint64_t>(delta));
+      AddStats(stats_.get(), flush_job_info.cf_id, file->GetDiscardableRatioLevel(), 1);
       file->FileStateTransit(BlobFileMeta::FileEvent::kFlushCompleted);
       ROCKS_LOG_INFO(db_options_.info_log,
                      "OnFlushCompleted[%d]: output blob file %" PRIu64

--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -1137,12 +1137,14 @@ void TitanDBImpl::OnFlushCompleted(const FlushJobInfo& flush_job_info) {
         assert(false);
         delta = 0;
       }
-      
+
       // the metrics is counted in the table builder when flushing,
       // so update it when updateing the live data size.
-      SubStats(stats_.get(), flush_job_info.cf_id, file->GetDiscardableRatioLevel(), 1);
+      SubStats(stats_.get(), flush_job_info.cf_id,
+               file->GetDiscardableRatioLevel(), 1);
       file->set_live_data_size(static_cast<uint64_t>(delta));
-      AddStats(stats_.get(), flush_job_info.cf_id, file->GetDiscardableRatioLevel(), 1);
+      AddStats(stats_.get(), flush_job_info.cf_id,
+               file->GetDiscardableRatioLevel(), 1);
       file->FileStateTransit(BlobFileMeta::FileEvent::kFlushCompleted);
       ROCKS_LOG_INFO(db_options_.info_log,
                      "OnFlushCompleted[%d]: output blob file %" PRIu64

--- a/src/db_impl_gc.cc
+++ b/src/db_impl_gc.cc
@@ -83,9 +83,11 @@ Status TitanDBImpl::InitializeGC(
           blob_storage->FindFile(file_size.first).lock();
       if (file != nullptr) {
         assert(file->live_data_size() == 0);
-        SubStats(stats_.get(), cf_handle->GetID(), file->GetDiscardableRatioLevel(), 1);
+        SubStats(stats_.get(), cf_handle->GetID(),
+                 file->GetDiscardableRatioLevel(), 1);
         file->set_live_data_size(static_cast<uint64_t>(file_size.second));
-        AddStats(stats_.get(), cf_handle->GetID(), file->GetDiscardableRatioLevel(), 1);
+        AddStats(stats_.get(), cf_handle->GetID(),
+                 file->GetDiscardableRatioLevel(), 1);
       }
     }
     blob_storage->InitializeAllFiles();

--- a/src/db_impl_gc.cc
+++ b/src/db_impl_gc.cc
@@ -83,7 +83,9 @@ Status TitanDBImpl::InitializeGC(
           blob_storage->FindFile(file_size.first).lock();
       if (file != nullptr) {
         assert(file->live_data_size() == 0);
+        SubStats(stats_.get(), cf_handle->GetID(), file->GetDiscardableRatioLevel(), 1);
         file->set_live_data_size(static_cast<uint64_t>(file_size.second));
+        AddStats(stats_.get(), cf_handle->GetID(), file->GetDiscardableRatioLevel(), 1);
       }
     }
     blob_storage->InitializeAllFiles();

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -425,41 +425,51 @@ TEST_F(TitanDBTest, GetProperty) {
   uint64_t value;
   ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumLiveBlobFile, &value));
   ASSERT_EQ(value, 1);
-  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE0File, &value));
+  ASSERT_TRUE(
+      GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE0File, &value));
   ASSERT_EQ(value, 1);
-  
+
   Reopen();
   ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumLiveBlobFile, &value));
   ASSERT_EQ(value, 1);
-  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE0File, &value));
+  ASSERT_TRUE(
+      GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE0File, &value));
   ASSERT_EQ(value, 1);
-  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE20File, &value));
+  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE20File,
+                             &value));
   ASSERT_EQ(value, 0);
-  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE50File, &value));
+  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE50File,
+                             &value));
   ASSERT_EQ(value, 0);
-  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE80File, &value));
+  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE80File,
+                             &value));
   ASSERT_EQ(value, 0);
-  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE100File, &value));
+  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE100File,
+                             &value));
   ASSERT_EQ(value, 0);
 
-  for (uint64_t k= 1; k <= 100; k++) {
+  for (uint64_t k = 1; k <= 100; k++) {
     if (k % 3 == 0) Delete(k);
   }
   Flush();
   CompactAll();
 
-  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE0File, &value));
-  ASSERT_EQ(value, 0); 
-  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE50File, &value));
-  ASSERT_EQ(value, 1); 
+  ASSERT_TRUE(
+      GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE0File, &value));
+  ASSERT_EQ(value, 0);
+  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE50File,
+                             &value));
+  ASSERT_EQ(value, 1);
 
   Reopen();
-  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE0File, &value));
-  ASSERT_EQ(value, 0); 
-  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE50File, &value));
-  ASSERT_EQ(value, 1); 
+  ASSERT_TRUE(
+      GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE0File, &value));
+  ASSERT_EQ(value, 0);
+  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE50File,
+                             &value));
+  ASSERT_EQ(value, 1);
 
-  for (uint64_t k= 1; k <= 100; k++) {
+  for (uint64_t k = 1; k <= 100; k++) {
     if (k % 3 != 0) Delete(k);
   }
   Flush();
@@ -468,12 +478,15 @@ TEST_F(TitanDBTest, GetProperty) {
   db_impl_->TEST_WaitForBackgroundGC();
   ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumLiveBlobFile, &value));
   ASSERT_EQ(value, 0);
-  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumObsoleteBlobFile, &value));
+  ASSERT_TRUE(
+      GetIntProperty(TitanDB::Properties::kNumObsoleteBlobFile, &value));
   ASSERT_EQ(value, 1);
   ASSERT_OK(db_impl_->TEST_PurgeObsoleteFiles());
-  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumObsoleteBlobFile, &value));
+  ASSERT_TRUE(
+      GetIntProperty(TitanDB::Properties::kNumObsoleteBlobFile, &value));
   ASSERT_EQ(value, 0);
-  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE50File, &value));
+  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE50File,
+                             &value));
   ASSERT_EQ(value, 0);
 }
 

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -416,6 +416,7 @@ TEST_F(TitanDBTest, DBIterSeek) {
 }
 
 TEST_F(TitanDBTest, GetProperty) {
+  options_.disable_background_gc = false;
   Open();
   for (uint64_t k = 1; k <= 100; k++) {
     Put(k);
@@ -424,9 +425,56 @@ TEST_F(TitanDBTest, GetProperty) {
   uint64_t value;
   ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumLiveBlobFile, &value));
   ASSERT_EQ(value, 1);
+  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE0File, &value));
+  ASSERT_EQ(value, 1);
+  
   Reopen();
   ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumLiveBlobFile, &value));
   ASSERT_EQ(value, 1);
+  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE0File, &value));
+  ASSERT_EQ(value, 1);
+  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE20File, &value));
+  ASSERT_EQ(value, 0);
+  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE50File, &value));
+  ASSERT_EQ(value, 0);
+  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE80File, &value));
+  ASSERT_EQ(value, 0);
+  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE100File, &value));
+  ASSERT_EQ(value, 0);
+
+  for (uint64_t k= 1; k <= 100; k++) {
+    if (k % 3 == 0) Delete(k);
+  }
+  Flush();
+  CompactAll();
+
+  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE0File, &value));
+  ASSERT_EQ(value, 0); 
+  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE50File, &value));
+  ASSERT_EQ(value, 1); 
+
+  Reopen();
+  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE0File, &value));
+  ASSERT_EQ(value, 0); 
+  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE50File, &value));
+  ASSERT_EQ(value, 1); 
+
+  for (uint64_t k= 1; k <= 100; k++) {
+    if (k % 3 != 0) Delete(k);
+  }
+  Flush();
+  CompactAll();
+
+  db_impl_->TEST_WaitForBackgroundGC();
+  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumLiveBlobFile, &value));
+  ASSERT_EQ(value, 0);
+  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumObsoleteBlobFile, &value));
+  ASSERT_EQ(value, 1);
+  ASSERT_OK(db_impl_->TEST_PurgeObsoleteFiles());
+  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumObsoleteBlobFile, &value));
+  ASSERT_EQ(value, 0);
+  ASSERT_TRUE(GetIntProperty(TitanDB::Properties::kNumDiscardableRatioLE50File, &value));
+  ASSERT_EQ(value, 0);
 }
 
 TEST_F(TitanDBTest, Snapshot) {


### PR DESCRIPTION
After creating a new blob file meta, the live data size is 0. The stat is counted when adding the blob file but with live_data_size == 0. So we should update the stat when the live data size is initialized.