### PR TITLE
Add interface MultiBatchWrite for TitanDB (#156)

### DIFF
--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -549,6 +549,12 @@ Status TitanDBImpl::Write(const rocksdb::WriteOptions& options,
   return HasBGError() ? GetBGError() : db_->Write(options, updates);
 }
 
+Status TitanDBImpl::MultiBatchWrite(const WriteOptions& options,
+                                    std::vector<WriteBatch*>&& updates) {
+  return HasBGError() ? GetBGError()
+                      : db_->MultiBatchWrite(options, std::move(updates));
+}
+
 Status TitanDBImpl::Delete(const rocksdb::WriteOptions& options,
                            rocksdb::ColumnFamilyHandle* column_family,
                            const rocksdb::Slice& key) {

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -62,6 +62,10 @@ class TitanDBImpl : public TitanDB {
   using TitanDB::Write;
   Status Write(const WriteOptions& options, WriteBatch* updates) override;
 
+  using TitanDB::MultiBatchWrite;
+  Status MultiBatchWrite(const WriteOptions& options,
+                         std::vector<WriteBatch*>&& updates) override;
+
   using TitanDB::Delete;
   Status Delete(const WriteOptions& options, ColumnFamilyHandle* column_family,
                 const Slice& key) override;


### PR DESCRIPTION
This is a new interface which is added to RocksDB recently and TiKV will call it if `enable_multi_thread_write` of `DBOptions` is true. So Titan must implement it by self.

Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>