### PR TITLE
Fix wrong live data size when encounter rewrite failure

### DIFF
--- a/src/blob_gc_job.cc
+++ b/src/blob_gc_job.cc
@@ -534,8 +534,6 @@ Status BlobGCJob::RewriteValidKeyToLSM() {
       }
       SubStats(stats_, cf_id, file->GetDiscardableRatioLevel(), 1);
       file->UpdateLiveDataSize(-blob_file.second);
-      fprintf(stderr, "update file %lu dropped %lu %lf", blob_file.first,
-              blob_file.second, file->GetDiscardableRatio());
       AddStats(stats_, cf_id, file->GetDiscardableRatioLevel(), 1);
 
       blob_storage->ComputeGCScore();

--- a/src/blob_gc_job.cc
+++ b/src/blob_gc_job.cc
@@ -347,6 +347,7 @@ Status BlobGCJob::Finish() {
     mutex_->Unlock();
     s = InstallOutputBlobFiles();
     if (s.ok()) {
+      TEST_SYNC_POINT("BlobGCJob::Finish::BeforeRewriteValidKeyToLSM");
       s = RewriteValidKeyToLSM();
       if (!s.ok()) {
         ROCKS_LOG_ERROR(db_options_.info_log,
@@ -368,6 +369,7 @@ Status BlobGCJob::Finish() {
   if (s.ok() && !blob_gc_->GetColumnFamilyData()->IsDropped()) {
     s = DeleteInputBlobFiles();
   }
+  TEST_SYNC_POINT("BlobGCJob::Finish::AfterRewriteValidKeyToLSM");
 
   if (s.ok()) {
     UpdateInternalOpStats();
@@ -451,6 +453,9 @@ Status BlobGCJob::RewriteValidKeyToLSM() {
   WriteOptions wo;
   wo.low_pri = true;
   wo.ignore_missing_column_families = true;
+
+  std::unordered_map<uint64_t, uint64_t>
+      dropped;  // blob_file_number -> dropped_size
   if (!gc_merge_rewrite_) {
     for (auto& write_batch : rewrite_batches_) {
       if (blob_gc_->GetColumnFamilyData()->IsDropped()) {
@@ -473,6 +478,13 @@ Status BlobGCJob::RewriteValidKeyToLSM() {
         metrics_.gc_num_keys_overwritten++;
         metrics_.gc_bytes_overwritten += write_batch.second.blob_record_size();
         // The key is overwritten in the meanwhile. Drop the blob record.
+        // Though record is dropped, the diff won't counted in discardable
+        // ratio,
+        // so we should update the live_data_size here.
+        BlobIndex blob_index;
+        Slice str(write_batch.second.value);
+        blob_index.DecodeFrom(&str);
+        dropped[blob_index.file_number] += blob_index.blob_handle.size;
       } else {
         // We hit an error.
         break;
@@ -507,6 +519,32 @@ Status BlobGCJob::RewriteValidKeyToLSM() {
   if (s.IsBusy()) {
     s = Status::OK();
   }
+
+  mutex_->Lock();
+  auto cf_id = blob_gc_->column_family_handle()->GetID();
+  for (auto blob_file : dropped) {
+    auto blob_storage = blob_file_set_->GetBlobStorage(cf_id).lock();
+    if (blob_storage) {
+      auto file = blob_storage->FindFile(blob_file.first).lock();
+      if (!file) {
+        ROCKS_LOG_ERROR(db_options_.info_log,
+                        "Blob File %" PRIu64 " not found when GC.",
+                        blob_file.first);
+        continue;
+      }
+      SubStats(stats_, cf_id, file->GetDiscardableRatioLevel(), 1);
+      file->UpdateLiveDataSize(-blob_file.second);
+      fprintf(stderr, "update file %lu dropped %lu %lf", blob_file.first,
+              blob_file.second, file->GetDiscardableRatio());
+      AddStats(stats_, cf_id, file->GetDiscardableRatioLevel(), 1);
+
+      blob_storage->ComputeGCScore();
+    } else {
+      ROCKS_LOG_ERROR(db_options_.info_log,
+                      "Column family id:%" PRIu32 " not Found when GC.", cf_id);
+    }
+  }
+  mutex_->Unlock();
 
   if (s.ok()) {
     // Flush and sync WAL.

--- a/src/db_impl_gc.cc
+++ b/src/db_impl_gc.cc
@@ -211,6 +211,7 @@ Status TitanDBImpl::BackgroundGC(LogBuffer* log_buffer,
     s = blob_gc_job.Prepare();
     if (s.ok()) {
       mutex_.Unlock();
+      TEST_SYNC_POINT("TitanDBImpl::BackgroundGC::BeforeRunGCJob");
       s = blob_gc_job.Run();
       mutex_.Lock();
     }

--- a/src/db_impl_gc.cc
+++ b/src/db_impl_gc.cc
@@ -211,8 +211,8 @@ Status TitanDBImpl::BackgroundGC(LogBuffer* log_buffer,
     s = blob_gc_job.Prepare();
     if (s.ok()) {
       mutex_.Unlock();
-      TEST_SYNC_POINT("TitanDBImpl::BackgroundGC::BeforeRunGCJob");
       s = blob_gc_job.Run();
+      TEST_SYNC_POINT("TitanDBImpl::BackgroundGC::AfterRunGCJob");
       mutex_.Lock();
     }
     if (s.ok()) {

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -9,7 +9,6 @@
 #include "test_util/sync_point.h"
 #include "test_util/testharness.h"
 #include "util/random.h"
-#include "util/stderr_logger.h"
 
 #include "blob_file_iterator.h"
 #include "blob_file_reader.h"
@@ -1406,7 +1405,6 @@ TEST_F(TitanDBTest, CompactionDuringGC) {
   options_.max_background_gc = 1;
   options_.disable_background_gc = false;
   options_.blob_file_discardable_ratio = 0.01;
-  options_.info_log.reset(new StderrLogger());
   Open();
 
   ASSERT_OK(db_->Put(WriteOptions(), "k1", std::string(10 * 1024, 'v')));

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -1431,14 +1431,15 @@ TEST_F(TitanDBTest, CompactionDuringGC) {
   CompactAll();
 
   ASSERT_OK(db_->Delete(WriteOptions(), "k1"));
-  blob_storage->ExportBlobFiles(blob_files);
-  // rewriting index to LSM failed, but the output blob file is already
-  // generated
-  ASSERT_EQ(blob_files.size(), 2);
 
   TEST_SYNC_POINT("TitanDBTest::CompactionDuringGC::ContinueGC");
   TEST_SYNC_POINT("TitanDBTest::CompactionDuringGC::WaitGC");
 
+  blob_storage->ExportBlobFiles(blob_files);
+  // rewriting index to LSM failed, but the output blob file is already
+  // generated
+  ASSERT_EQ(blob_files.size(), 2);
+  
   std::string value;
   Status status = db_->Get(ReadOptions(), "k1", &value);
   ASSERT_EQ(status, Status::NotFound());

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -9,6 +9,7 @@
 #include "test_util/sync_point.h"
 #include "test_util/testharness.h"
 #include "util/random.h"
+#include "util/stderr_logger.h"
 
 #include "blob_file_iterator.h"
 #include "blob_file_reader.h"
@@ -1405,6 +1406,7 @@ TEST_F(TitanDBTest, CompactionDuringGC) {
   options_.max_background_gc = 1;
   options_.disable_background_gc = false;
   options_.blob_file_discardable_ratio = 0.01;
+  options_.info_log.reset(new StderrLogger());
   Open();
 
   ASSERT_OK(db_->Put(WriteOptions(), "k1", std::string(10 * 1024, 'v')));

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -1415,7 +1415,7 @@ TEST_F(TitanDBTest, CompactionDuringGC) {
   db_->ReleaseSnapshot(snap);
 
   SyncPoint::GetInstance()->LoadDependency(
-      {{"TitanDBImpl::BackgroundGC::BeforeRunGCJob",
+      {{"TitanDBImpl::BackgroundGC::AfterRunGCJob",
         "TitanDBTest::CompactionDuringGC::WaitGCStart"},
        {"TitanDBTest::CompactionDuringGC::ContinueGC",
         "BlobGCJob::Finish::BeforeRewriteValidKeyToLSM"},

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -1439,7 +1439,7 @@ TEST_F(TitanDBTest, CompactionDuringGC) {
   // rewriting index to LSM failed, but the output blob file is already
   // generated
   ASSERT_EQ(blob_files.size(), 2);
-  
+
   std::string value;
   Status status = db_->Get(ReadOptions(), "k1", &value);
   ASSERT_EQ(status, Status::NotFound());

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -155,6 +155,17 @@ class TitanDBTest : public testing::Test {
     return db_impl_->blob_file_set_->GetBlobStorage(cf_handle->GetID());
   }
 
+  void CheckBlobFileCount(int count, ColumnFamilyHandle* cf_handle = nullptr) {
+    db_impl_->TEST_WaitForBackgroundGC();
+    ASSERT_OK(db_impl_->TEST_PurgeObsoleteFiles());
+    std::shared_ptr<BlobStorage> blob_storage =
+        GetBlobStorage(cf_handle).lock();
+    ASSERT_TRUE(blob_storage != nullptr);
+    std::map<uint64_t, std::weak_ptr<BlobFileMeta>> blob_files;
+    blob_storage->ExportBlobFiles(blob_files);
+    ASSERT_EQ(count, blob_files.size());
+  }
+
   ColumnFamilyHandle* GetColumnFamilyHandle(uint32_t cf_id) {
     return db_impl_->db_impl_->GetColumnFamilyHandleUnlocked(cf_id).release();
   }
@@ -220,13 +231,17 @@ class TitanDBTest : public testing::Test {
     }
   }
 
-  void CompactAll() {
+  void CompactAll(ColumnFamilyHandle* cf_handle = nullptr) {
+    if (cf_handle == nullptr) {
+      cf_handle = db_->DefaultColumnFamily();
+    }
     auto opts = db_->GetOptions();
     auto compact_opts = CompactRangeOptions();
     compact_opts.change_level = true;
     compact_opts.target_level = opts.num_levels - 1;
-    compact_opts.bottommost_level_compaction = BottommostLevelCompaction::kSkip;
-    ASSERT_OK(db_->CompactRange(compact_opts, nullptr, nullptr));
+    compact_opts.bottommost_level_compaction =
+        BottommostLevelCompaction::kForce;
+    ASSERT_OK(db_->CompactRange(compact_opts, cf_handle, nullptr, nullptr));
   }
 
   void DeleteFilesInRange(const Slice* begin, const Slice* end) {
@@ -1384,6 +1399,59 @@ TEST_F(TitanDBTest, GCAfterReopen) {
   ASSERT_EQ(1, blob_files.size());
   std::shared_ptr<BlobFileMeta> file2 = blob_files.begin()->second.lock();
   ASSERT_GT(file2->file_number(), file_number1);
+}
+
+TEST_F(TitanDBTest, CompactionDuringGC) {
+  options_.max_background_gc = 2;
+  options_.disable_background_gc = false;
+  options_.blob_file_discardable_ratio = 0.01;
+  Open();
+
+  ASSERT_OK(db_->Put(WriteOptions(), "k1", std::string(10 * 1024, 'v')));
+  auto snap = db_->GetSnapshot();
+  ASSERT_OK(db_->Put(WriteOptions(), "k1", std::string(100 * 1024, 'v')));
+  Flush();
+
+  db_->ReleaseSnapshot(snap);
+  CheckBlobFileCount(1);
+  std::shared_ptr<BlobStorage> blob_storage = GetBlobStorage().lock();
+  ASSERT_TRUE(blob_storage != nullptr);
+  std::map<uint64_t, std::weak_ptr<BlobFileMeta>> blob_files;
+  blob_storage->ExportBlobFiles(blob_files);
+  ASSERT_EQ(blob_files.size(), 1);
+  CompactAll();
+
+  SyncPoint::GetInstance()->LoadDependency(
+      {{"TitanDBTest::CompactionDuringGC::ContinueGC",
+        "BlobGCJob::Finish::BeforeRewriteValidKeyToLSM"},
+       {"BlobGCJob::Finish::AfterRewriteValidKeyToLSM",
+        "TitanDBTest::CompactionDuringGC::WaitGC"}});
+  SyncPoint::GetInstance()->EnableProcessing();
+  // trigger GC
+  CompactAll();
+
+  ASSERT_OK(db_->Delete(WriteOptions(), "k1"));
+  blob_storage->ExportBlobFiles(blob_files);
+  // rewriting index to LSM failed, but the output blob file is already
+  // generated
+  ASSERT_EQ(blob_files.size(), 2);
+
+  TEST_SYNC_POINT("TitanDBTest::CompactionDuringGC::ContinueGC");
+  TEST_SYNC_POINT("TitanDBTest::CompactionDuringGC::WaitGC");
+
+  std::string value;
+  Status status = db_->Get(ReadOptions(), "k1", &value);
+  ASSERT_EQ(status, Status::NotFound());
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  CheckBlobFileCount(1);
+
+  Flush();
+  CompactAll();
+  CompactAll();
+
+  db_impl_->TEST_StartGC(db_impl_->DefaultColumnFamily()->GetID());
+  CheckBlobFileCount(0);
 }
 
 }  // namespace titandb

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -1402,7 +1402,7 @@ TEST_F(TitanDBTest, GCAfterReopen) {
 }
 
 TEST_F(TitanDBTest, CompactionDuringGC) {
-  options_.max_background_gc = 2;
+  options_.max_background_gc = 1;
   options_.disable_background_gc = false;
   options_.blob_file_discardable_ratio = 0.01;
   Open();
@@ -1414,12 +1414,12 @@ TEST_F(TitanDBTest, CompactionDuringGC) {
 
   db_->ReleaseSnapshot(snap);
   CheckBlobFileCount(1);
+  CompactAll();
   std::shared_ptr<BlobStorage> blob_storage = GetBlobStorage().lock();
   ASSERT_TRUE(blob_storage != nullptr);
   std::map<uint64_t, std::weak_ptr<BlobFileMeta>> blob_files;
   blob_storage->ExportBlobFiles(blob_files);
   ASSERT_EQ(blob_files.size(), 1);
-  CompactAll();
 
   SyncPoint::GetInstance()->LoadDependency(
       {{"TitanDBTest::CompactionDuringGC::ContinueGC",


### PR DESCRIPTION
Consider the case when GC is rewriting the new blob index to LSM, there is a concurrent front ground update the value of the blob index corresponding key. So the rewrite callback will fail, and the blob record is dropped silently.

The record is actually discarded, but we didn't update the live data size. So it may avoid the file being GCed.