### PR TITLE
not hold mutex when destruct big object

### DIFF
--- a/src/db_impl_gc.cc
+++ b/src/db_impl_gc.cc
@@ -202,21 +202,26 @@ Status TitanDBImpl::BackgroundGC(LogBuffer* log_buffer,
     ROCKS_LOG_BUFFER(log_buffer, "Titan GC nothing to do");
   } else {
     StopWatch gc_sw(env_, statistics(stats_.get()), TITAN_GC_MICROS);
-    BlobGCJob blob_gc_job(blob_gc.get(), db_, &mutex_, db_options_,
-                          gc_merge_rewrite, env_, env_options_,
-                          blob_manager_.get(), blob_file_set_.get(), log_buffer,
-                          &shuting_down_, stats_.get());
-    s = blob_gc_job.Prepare();
+    BlobGCJob *blob_gc_job = new BlobGCJob(blob_gc.get(), db_, &mutex_, db_options_,
+                                           gc_merge_rewrite, env_, env_options_,
+                                           blob_manager_.get(), blob_file_set_.get(), log_buffer,
+                                           &shuting_down_, stats_.get());
+    s = blob_gc_job->Prepare();
     if (s.ok()) {
       mutex_.Unlock();
       TEST_SYNC_POINT("TitanDBImpl::BackgroundGC::BeforeRunGCJob");
-      s = blob_gc_job.Run();
+      s = blob_gc_job->Run();
       TEST_SYNC_POINT("TitanDBImpl::BackgroundGC::AfterRunGCJob");
       mutex_.Lock();
     }
     if (s.ok()) {
-      s = blob_gc_job.Finish();
+      s = blob_gc_job->Finish();
     }
+
+    mutex_.Unlock();
+    delete blob_gc_job;
+    mutex_.Lock();
+
     blob_gc->ReleaseGcFiles();
 
     if (blob_gc->trigger_next() &&


### PR DESCRIPTION
我们线上使用titan的时候经常发现get会产生几百毫秒延时，原因是get命令创建snapshot的时候会mutex_.Lock()。但BlobGCJob对象在析构的时候会持有mutex_，该对象中保存了需要回写sst中的kv，如果需要回写的kv很多（线下测试可能会有几十万条），那么该对象会很大，析构的时候比较耗时，持有mutex_的时间就会比较长，导致get命令加锁被阻塞。所以建议析构大对象的时候，不要持有锁。我们修复后，线上已经跑了一个月，get已经不会产生延时抖动。