### PR TITLE
Fix Segment fault when creates TitanCompactionFilter

### DIFF
--- a/src/compaction_filter.h
+++ b/src/compaction_filter.h
@@ -158,7 +158,9 @@ class TitanCompactionFilterFactory final : public CompactionFilterFactory {
       original_filter = original_filter_from_factory.get();
     }
 
-    if (UNLIKELY(original_filter == nullptr)) return nullptr;
+    if (original_filter == nullptr) {
+      return nullptr;
+    }
 
     return std::unique_ptr<CompactionFilter>(new TitanCompactionFilter(
         titan_db_impl_, cf_name_, original_filter,

--- a/src/compaction_filter.h
+++ b/src/compaction_filter.h
@@ -157,6 +157,9 @@ class TitanCompactionFilterFactory final : public CompactionFilterFactory {
           original_filter_factory_->CreateCompactionFilter(context);
       original_filter = original_filter_from_factory.get();
     }
+
+    if (UNLIKELY(original_filter == nullptr)) return nullptr;
+
     return std::unique_ptr<CompactionFilter>(new TitanCompactionFilter(
         titan_db_impl_, cf_name_, original_filter,
         std::move(original_filter_from_factory), blob_storage, skip_value_));


### PR DESCRIPTION
Looks like it's not a undefined behavior to get a nullptr from compaction filter factory

Fixes #180 