### PR TITLE
separate DeleteBlobFilesInRange from DeleteFilesInRange

### DIFF
--- a/include/titan/db.h
+++ b/include/titan/db.h
@@ -128,6 +128,10 @@ class TitanDB : public StackableDB {
                                      const RangePtr* ranges, size_t n,
                                      bool include_end = true) = 0;
 
+  virtual Status DeleteBlobFilesInRanges(ColumnFamilyHandle* column_family,
+                                     const RangePtr* ranges, size_t n,
+                                     bool include_end = true) = 0;
+
   using rocksdb::StackableDB::GetOptions;
   Options GetOptions(ColumnFamilyHandle* column_family) const override = 0;
 

--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -862,11 +862,6 @@ Status TitanDBImpl::DeleteFilesInRanges(ColumnFamilyHandle* column_family,
   if (!s.ok()) return s;
 
   MutexLock l(&mutex_);
-  SequenceNumber obsolete_sequence = db_impl_->GetLatestSequenceNumber();
-  s = blob_file_set_->DeleteBlobFilesInRanges(cf_id, ranges, n, include_end,
-                                              obsolete_sequence);
-  if (!s.ok()) return s;
-
   auto bs = blob_file_set_->GetBlobStorage(cf_id).lock();
   if (!bs) {
     // TODO: Should treat it as background error and make DB read-only.
@@ -922,6 +917,16 @@ Status TitanDBImpl::DeleteFilesInRanges(ColumnFamilyHandle* column_family,
     MaybeScheduleGC();
   }
 
+  return s;
+}
+
+Status TitanDBImpl::DeleteBlobFilesInRanges(ColumnFamilyHandle* column_family,
+                                        const RangePtr* ranges, size_t n,
+                                        bool include_end) {
+  MutexLock l(&mutex_);
+  SequenceNumber obsolete_sequence = db_impl_->GetLatestSequenceNumber();
+  Status s = blob_file_set_->DeleteBlobFilesInRanges(column_family->GetID(), ranges, n, include_end,
+                                              obsolete_sequence);
   return s;
 }
 

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -114,6 +114,10 @@ class TitanDBImpl : public TitanDB {
                              const RangePtr* ranges, size_t n,
                              bool include_end = true) override;
 
+  Status DeleteBlobFilesInRanges(ColumnFamilyHandle* column_family,
+                                     const RangePtr* ranges, size_t n,
+                                     bool include_end = true) override;
+
   using TitanDB::GetOptions;
   Options GetOptions(ColumnFamilyHandle* column_family) const override;
 

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -247,6 +247,7 @@ class TitanDBTest : public testing::Test {
   void DeleteFilesInRange(const Slice* begin, const Slice* end) {
     RangePtr range(begin, end);
     ASSERT_OK(db_->DeleteFilesInRanges(db_->DefaultColumnFamily(), &range, 1));
+    ASSERT_OK(db_->DeleteBlobFilesInRanges(db_->DefaultColumnFamily(), &range, 1));
   }
 
   std::string GenKey(uint64_t i) {


### PR DESCRIPTION
Separate `DeleteBlobFilesInRange` from `DeleteFilesInRange` to give upper application more flexibility.