### PR TITLE
Add dictionary compression support for blob file

### DIFF
--- a/include/titan/options.h
+++ b/include/titan/options.h
@@ -85,6 +85,11 @@ struct TitanCFOptions : public ColumnFamilyOptions {
   // Default: kNoCompression
   CompressionType blob_file_compression{kNoCompression};
 
+  // The compression options
+  //
+  // Default: disabled
+  CompressionOptions blob_file_compression_options;
+
   // The desirable blob file size. This is not a hard limit but a wish.
   //
   // Default: 256MB

--- a/include/titan/options.h
+++ b/include/titan/options.h
@@ -85,9 +85,10 @@ struct TitanCFOptions : public ColumnFamilyOptions {
   // Default: kNoCompression
   CompressionType blob_file_compression{kNoCompression};
 
-  // The compression options
-  //
-  // Default: disabled
+  // The compression options. The `blob_file_compression.enabled` option is
+  // ignored, we only use `blob_file_compression` above to determine wether the
+  // blob file is compressed. We use this options mainly to configure the
+  // compression dictionary.
   CompressionOptions blob_file_compression_options;
 
   // The desirable blob file size. This is not a hard limit but a wish.

--- a/src/blob_file_builder.cc
+++ b/src/blob_file_builder.cc
@@ -91,7 +91,7 @@ void BlobFileBuilder::EnterUnbuffered() {
 void BlobFileBuilder::FlushSampleRecords() {
   BlobHandle handle;
   for (const std::string& record_str : sample_records_) {
-    encoder_.EncodeString(record_str);
+    encoder_.EncodeSlice(record_str);
     WriteEncoderData(&handle);
   }
   sample_records_.clear();

--- a/src/blob_file_builder.cc
+++ b/src/blob_file_builder.cc
@@ -124,7 +124,7 @@ void BlobFileBuilder::WriteRawBlock(const Slice& block, BlockHandle* handle) {
 
     // crc32 checksum
     auto crc = crc32c::Value(block.data(), block.size());
-    crc = crc32c::Extend(crc, trailer, 1);  // Extend to cover block type
+    crc = crc32c::Extend(crc, trailer, 1);  // Extend to cover compression type
     EncodeFixed32(trailer_without_type, crc32c::Mask(crc));
     status_ = file_->Append(Slice(trailer, kBlockTrailerSize));
   }

--- a/src/blob_file_builder.cc
+++ b/src/blob_file_builder.cc
@@ -13,6 +13,12 @@ BlobFileBuilder::BlobFileBuilder(const TitanDBOptions& db_options,
       file_(file),
       encoder_(cf_options_.blob_file_compression,
                cf_options.blob_file_compression_options) {
+#if ZSTD_VERSION_NUMBER < 10103
+  if (cf_options_.blob_file_compression_options.max_dict_bytes > 0) {
+    status_ = Status::NotSupported("ZSTD version too old.");
+    return;
+  }
+#endif
   if (file_) WriteHeader();
 }
 

--- a/src/blob_file_builder.cc
+++ b/src/blob_file_builder.cc
@@ -27,7 +27,7 @@ void BlobFileBuilder::Add(const BlobRecord& record, BlobHandle* handle) {
     std::string rec_str;
     record.EncodeTo(&rec_str);
     sample_records_.emplace_back(rec_str);
-    sample_str_len_ += (16 /* 2 extra Varint64 */ + record.size());
+    sample_str_len_ += rec_str.size();
     if (cf_options_.blob_file_compression_options.zstd_max_train_bytes > 0 &&
         sample_str_len_ >=
             cf_options_.blob_file_compression_options.zstd_max_train_bytes) {

--- a/src/blob_file_builder.cc
+++ b/src/blob_file_builder.cc
@@ -11,7 +11,7 @@ BlobFileBuilder::BlobFileBuilder(const TitanDBOptions& db_options,
                          : BuilderState::kUnbuffered),
       cf_options_(cf_options),
       file_(file),
-      encoder_(cf_options_.blob_file_compression,
+      encoder_(cf_options.blob_file_compression,
                cf_options.blob_file_compression_options) {
 #if ZSTD_VERSION_NUMBER < 10103
   if (cf_options_.blob_file_compression_options.max_dict_bytes > 0) {
@@ -84,7 +84,7 @@ void BlobFileBuilder::EnterUnbuffered(OutContexts* out_ctx) {
   // Using collected samples to train the compression dictionary
   // Then replay those records in memory, encode them to blob file
   // When above things are done, transform builder state into unbuffered
-  std::string samples = "";
+  std::string samples;
   samples.reserve(sample_str_len_);
   std::vector<size_t> sample_lens;
 

--- a/src/blob_file_builder.cc
+++ b/src/blob_file_builder.cc
@@ -122,10 +122,9 @@ void BlobFileBuilder::EnterUnbuffered(OutContexts* out_ctx) {
 
 void BlobFileBuilder::FlushSampleRecords(OutContexts* out_ctx) {
   assert(cached_contexts_.size() >= sample_records_.size());
-  size_t i, j;
-  for (i = 0; i < sample_records_.size(); i++, j++) {
+  size_t i = 0, j = 0;
+  for (; i < sample_records_.size(); i++, j++) {
     const std::string& record_str = sample_records_[i];
-    j = i;
     for (; j < cached_contexts_.size() &&
            cached_contexts_[j]->small_kv_ctx.is_small;
          j++) {

--- a/src/blob_file_builder.cc
+++ b/src/blob_file_builder.cc
@@ -40,7 +40,7 @@ BlobFileBuilder::BlobRecordContexts BlobFileBuilder::Add(
     }
   } else if (builder_state_ == BuilderState::kUnbuffered) {
     encoder_.EncodeRecord(record);
-    WriteEncoderData(&ctx->index.blob_handle);
+    WriteEncoderData(&ctx->new_blob_index.blob_handle);
     ret.push_back(std::move(ctx));
   }
 
@@ -97,7 +97,7 @@ BlobFileBuilder::BlobRecordContexts BlobFileBuilder::FlushSampleRecords() {
     const std::string& record_str = sample_records_[i];
     const std::unique_ptr<BlobRecordContext>& ctx = cached_contexts_[i];
     encoder_.EncodeSlice(record_str);
-    WriteEncoderData(&ctx->index.blob_handle);
+    WriteEncoderData(&ctx->new_blob_index.blob_handle);
   }
   sample_records_.clear();
   sample_str_len_ = 0;

--- a/src/blob_file_builder.cc
+++ b/src/blob_file_builder.cc
@@ -92,7 +92,6 @@ BlobIndices BlobFileBuilder::EnterUnbuffered() {
 }
 
 BlobIndices BlobFileBuilder::FlushSampleRecords() {
-  BlobIndices ret;
   assert(cached_indices_.size() == sample_records_.size());
   for (size_t i = 0; i < sample_records_.size(); i++) {
     const std::string& record_str = sample_records_[i];
@@ -100,10 +99,10 @@ BlobIndices BlobFileBuilder::FlushSampleRecords() {
         cached_indices_[i];
     encoder_.EncodeSlice(record_str);
     WriteEncoderData(&key_index.second->blob_handle);
-    ret.push_back(key_index);
   }
   sample_records_.clear();
   sample_str_len_ = 0;
+  BlobIndices ret = std::move(cached_indices_);
   cached_indices_.clear();
   return ret;
 }

--- a/src/blob_file_builder.cc
+++ b/src/blob_file_builder.cc
@@ -25,6 +25,7 @@ void BlobFileBuilder::Add(const BlobRecord& record, BlobHandle* handle) {
   if (!ok()) return;
   if (builder_state_ == BuilderState::kBuffered) {
     std::string rec_str;
+    // Encode to take ownership of underlying string.
     record.EncodeTo(&rec_str);
     sample_records_.emplace_back(rec_str);
     sample_str_len_ += rec_str.size();

--- a/src/blob_file_builder.cc
+++ b/src/blob_file_builder.cc
@@ -66,7 +66,7 @@ void BlobFileBuilder::Add(const BlobRecord& record,
   largest_key_.assign(record.key.data(), record.key.size());
 }
 
-void BlobFileBuilder::CacheContext(std::unique_ptr<BlobRecordContext> ctx) {
+void BlobFileBuilder::AddSmall(std::unique_ptr<BlobRecordContext> ctx) {
   cached_contexts_.emplace_back(std::move(ctx));
 }
 
@@ -103,7 +103,7 @@ void BlobFileBuilder::FlushSampleRecords(OutContexts* out_ctx) {
   for (; sample_idx < sample_records_.size(); sample_idx++, ctx_idx++) {
     const std::string& record_str = sample_records_[sample_idx];
     for (; ctx_idx < cached_contexts_.size() &&
-           cached_contexts_[ctx_idx]->cached_data.is_cached;
+           cached_contexts_[ctx_idx]->has_value;
          ctx_idx++) {
       out_ctx->emplace_back(std::move(cached_contexts_[ctx_idx]));
     }

--- a/src/blob_file_builder.cc
+++ b/src/blob_file_builder.cc
@@ -24,8 +24,9 @@ BlobFileBuilder::BlobFileBuilder(const TitanDBOptions& db_options,
 
 void BlobFileBuilder::WriteHeader() {
   BlobFileHeader header;
-  if (cf_options_.blob_file_compression_options.max_dict_bytes > 0)
+  if (cf_options_.blob_file_compression_options.max_dict_bytes > 0) {
     header.flags |= BlobFileHeader::kHasUncompressionDictionary;
+  }
   std::string buffer;
   header.EncodeTo(&buffer);
   status_ = file_->Append(buffer);
@@ -48,7 +49,7 @@ void BlobFileBuilder::Add(const BlobRecord& record,
             cf_options_.blob_file_compression_options.zstd_max_train_bytes) {
       EnterUnbuffered(out_ctx);
     }
-  } else if (builder_state_ == BuilderState::kUnbuffered) {
+  } else {
     encoder_.EncodeRecord(record);
     WriteEncoderData(&ctx->new_blob_index.blob_handle);
     out_ctx->emplace_back(std::move(ctx));

--- a/src/blob_file_builder.cc
+++ b/src/blob_file_builder.cc
@@ -90,7 +90,7 @@ void BlobFileBuilder::EnterUnbuffered(OutContexts* out_ctx) {
   compression_dict_.reset(
       new CompressionDict(dict, cf_options_.blob_file_compression,
                           cf_options_.blob_file_compression_options.level));
-  encoder_.SetCompressionDict(*compression_dict_);
+  encoder_.SetCompressionDict(compression_dict_.get());
 
   FlushSampleRecords(out_ctx);
 

--- a/src/blob_file_builder.cc
+++ b/src/blob_file_builder.cc
@@ -79,21 +79,8 @@ void BlobFileBuilder::EnterUnbuffered(OutContexts* out_ctx) {
   std::vector<size_t> sample_lens;
 
   for (const auto& record_str : sample_records_) {
-    if (cf_options_.blob_file_compression_options.zstd_max_train_bytes > 0 &&
-        samples.size() >=
-            cf_options_.blob_file_compression_options.zstd_max_train_bytes) {
-      // Enough training data
-      break;
-    }
-    size_t copy_len =
-        cf_options_.blob_file_compression_options.zstd_max_train_bytes == 0
-            ? record_str.size()
-            : std::min(cf_options_.blob_file_compression_options
-                               .zstd_max_train_bytes -
-                           samples.size(),
-                       record_str.size());
-    samples.append(record_str, 0, copy_len);
-    sample_lens.emplace_back(copy_len);
+    samples.append(record_str, 0, record_str.size());
+    sample_lens.emplace_back(record_str.size());
   }
   std::string dict;
   dict = ZSTD_TrainDictionary(

--- a/src/blob_file_builder.cc
+++ b/src/blob_file_builder.cc
@@ -188,7 +188,6 @@ Status BlobFileBuilder::Finish(OutContexts* out_ctx) {
     WriteCompressionDictBlock(&meta_index_builder, &uncompression_dict_handle);
     WriteRawBlock(meta_index_builder.Finish(), &meta_index_handle);
     footer.meta_index_handle = meta_index_handle;
-    footer.uncompression_dict_handle = uncompression_dict_handle;
   }
 
   std::string buffer;

--- a/src/blob_file_builder.cc
+++ b/src/blob_file_builder.cc
@@ -152,10 +152,11 @@ void BlobFileBuilder::WriteRawBlock(const Slice& block, BlockHandle* handle) {
 }
 
 void BlobFileBuilder::WriteCompressionDictBlock(
-    MetaIndexBuilder* meta_index_builder, BlockHandle* handle) {
-  WriteRawBlock(compression_dict_->GetRawDict(), handle);
+    MetaIndexBuilder* meta_index_builder) {
+  BlockHandle handle;
+  WriteRawBlock(compression_dict_->GetRawDict(), &handle);
   if (ok()) {
-    meta_index_builder->Add(kCompressionDictBlock, *handle);
+    meta_index_builder->Add(kCompressionDictBlock, handle);
   }
 }
 
@@ -168,11 +169,10 @@ Status BlobFileBuilder::Finish(OutContexts* out_ctx) {
 
   BlobFileFooter footer;
   // if has compression dictionary, encode it into meta blocks
-  // and update relative fields in footer
   if (cf_options_.blob_file_compression_options.max_dict_bytes > 0) {
-    BlockHandle meta_index_handle, uncompression_dict_handle;
+    BlockHandle meta_index_handle;
     MetaIndexBuilder meta_index_builder;
-    WriteCompressionDictBlock(&meta_index_builder, &uncompression_dict_handle);
+    WriteCompressionDictBlock(&meta_index_builder);
     WriteRawBlock(meta_index_builder.Finish(), &meta_index_handle);
     footer.meta_index_handle = meta_index_handle;
   }

--- a/src/blob_file_builder.cc
+++ b/src/blob_file_builder.cc
@@ -65,10 +65,7 @@ void BlobFileBuilder::Add(const BlobRecord& record,
   largest_key_.assign(record.key.data(), record.key.size());
 }
 
-void BlobFileBuilder::CacheSmallKV(const BlobRecord& record,
-                                   std::unique_ptr<BlobRecordContext> ctx) {
-  ctx->small_kv_ctx.is_small = true;
-  ctx->small_kv_ctx.value = record.value.ToString();
+void BlobFileBuilder::CacheContext(std::unique_ptr<BlobRecordContext> ctx) {
   cached_contexts_.emplace_back(std::move(ctx));
 }
 
@@ -118,7 +115,7 @@ void BlobFileBuilder::FlushSampleRecords(OutContexts* out_ctx) {
   for (; i < sample_records_.size(); i++, j++) {
     const std::string& record_str = sample_records_[i];
     for (; j < cached_contexts_.size() &&
-           cached_contexts_[j]->small_kv_ctx.is_small;
+           cached_contexts_[j]->cached_data.is_cached;
          j++) {
       out_ctx->emplace_back(std::move(cached_contexts_[j]));
     }

--- a/src/blob_file_builder.h
+++ b/src/blob_file_builder.h
@@ -36,8 +36,9 @@ class BlobFileBuilder {
  public:
   class BlobRecordContext {
    public:
-    std::string key;
-    BlobIndex index;
+    std::string key;  // original internal key
+    BlobIndex original_blob_index;
+    BlobIndex new_blob_index;
   };
   typedef std::vector<std::unique_ptr<BlobRecordContext>> BlobRecordContexts;
 

--- a/src/blob_file_builder.h
+++ b/src/blob_file_builder.h
@@ -54,6 +54,12 @@ class BlobFileBuilder {
   BlobFileBuilder(const TitanDBOptions& db_options,
                   const TitanCFOptions& cf_options, WritableFileWriter* file);
 
+  // SetFileWriter can only be called when current writer is null.
+  void SetFileWriter(WritableFileWriter* file);
+
+  // If file_ is not null, return true.
+  bool HasFileWriter();
+
   // Adds the record to the file, return `BlobIndices`
   // Notice: return value might be empty when builder is in `kBuffered` state,
   // and caller should set `ctx.new_blob_index.file_number` before pass it in,
@@ -110,6 +116,7 @@ class BlobFileBuilder {
   BuilderState builder_state_;
 
   bool ok() const { return status().ok(); }
+  void WriteHeader();
   void WriteRawBlock(const Slice& block, BlockHandle* handle);
   void WriteCompressionDictBlock(MetaIndexBuilder* meta_index_builder,
                                  BlockHandle* handle);

--- a/src/blob_file_builder.h
+++ b/src/blob_file_builder.h
@@ -94,6 +94,7 @@ class BlobFileBuilder {
   void WriteCompressionDictBlock(MetaIndexBuilder* meta_index_builder,
                                  BlockHandle* handle);
   void FlushSampleRecords();
+  void WriteEncoderData(BlobHandle* handle);
 
   TitanCFOptions cf_options_;
   WritableFileWriter* file_;

--- a/src/blob_file_builder.h
+++ b/src/blob_file_builder.h
@@ -42,19 +42,25 @@ class BlobFileBuilder {
   BlobFileBuilder(const TitanDBOptions& db_options,
                   const TitanCFOptions& cf_options, WritableFileWriter* file);
 
-  // Adds the record to the file and points the handle to it.
+  // Adds the record to the file, return `BlobIndices`
+  // Notice: return value might be empty when builder is in `kBuffered` state,
+  // and the index parameter should set its `file_number` before passed in, the
+  // builder will only change the `blob_handle` of it
   BlobIndices Add(const BlobRecord& record, std::unique_ptr<BlobIndex> index);
 
   // Enter unbuffered state, only be called after collecting enough samples
-  // for compression dictionary
+  // for compression dictionary. It will return `BlobIndices` of the buffered
+  // records
   BlobIndices EnterUnbuffered();
 
   // Returns non-ok iff some error has been detected.
   Status status() const { return status_; }
 
   // Finishes building the table.
+  // This method will return non-empty `BlobIndices` when it is called in
+  // `kBuffered` state.
   // REQUIRES: Finish(), Abandon() have not been called.
-  Status Finish();
+  BlobIndices Finish(Status* status);
 
   // Abandons building the table. If the caller is not going to call
   // Finish(), it must call Abandon() before destroying this builder.

--- a/src/blob_file_builder.h
+++ b/src/blob_file_builder.h
@@ -99,8 +99,11 @@ class BlobFileBuilder {
 
   Status status_;
   BlobEncoder encoder_;
-  std::vector<BlobRecord> sample_records_;
+
+  // following 3 may be refactored in to Rep
+  std::vector<std::string> sample_records_;
   uint64_t sample_str_len_ = 0;
+  std::unique_ptr<CompressionDict> compression_dict_;
 
   uint64_t num_entries_ = 0;
   std::string smallest_key_;

--- a/src/blob_file_builder.h
+++ b/src/blob_file_builder.h
@@ -32,7 +32,8 @@ namespace titandb {
 // meta index block with block handles pointed to the meta blocks. The
 // meta block and the meta index block are formatted the same as the
 // BlockBasedTable.
-typedef std::vector<std::pair<Slice, std::unique_ptr<BlobIndex>>> BlobIndices;
+typedef std::vector<std::pair<std::string, std::unique_ptr<BlobIndex>>>
+    BlobIndices;
 
 class BlobFileBuilder {
  public:

--- a/src/blob_file_builder.h
+++ b/src/blob_file_builder.h
@@ -39,6 +39,12 @@ class BlobFileBuilder {
     std::string key;  // original internal key
     BlobIndex original_blob_index;
     BlobIndex new_blob_index;
+    class SmallKVContetx {
+     public:
+      SmallKVContetx() : is_small(false) {}
+      bool is_small;
+      std::string value;
+    } small_kv_ctx;
   };
   typedef autovector<std::unique_ptr<BlobRecordContext>> OutContexts;
 

--- a/src/blob_file_builder.h
+++ b/src/blob_file_builder.h
@@ -93,6 +93,7 @@ class BlobFileBuilder {
   void WriteRawBlock(const Slice& block, BlockHandle* handle);
   void WriteCompressionDictBlock(MetaIndexBuilder* meta_index_builder,
                                  BlockHandle* handle);
+  void FlushSampleRecords();
 
   TitanCFOptions cf_options_;
   WritableFileWriter* file_;

--- a/src/blob_file_builder.h
+++ b/src/blob_file_builder.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "blob_format.h"
+#include "table/meta_blocks.h"
 #include "titan/options.h"
 #include "util/compression.h"
 #include "util/file_reader_writer.h"
@@ -89,6 +90,9 @@ class BlobFileBuilder {
   BuilderState builder_state_;
 
   bool ok() const { return status().ok(); }
+  void WriteRawBlock(const Slice& block, BlockHandle* handle);
+  void WriteCompressionDictBlock(MetaIndexBuilder* meta_index_builder,
+                                 BlockHandle* handle);
 
   TitanCFOptions cf_options_;
   WritableFileWriter* file_;

--- a/src/blob_file_builder.h
+++ b/src/blob_file_builder.h
@@ -2,6 +2,7 @@
 
 #include "blob_format.h"
 #include "titan/options.h"
+#include "util/compression.h"
 #include "util/file_reader_writer.h"
 
 namespace rocksdb {
@@ -42,6 +43,10 @@ class BlobFileBuilder {
   // Adds the record to the file and points the handle to it.
   void Add(const BlobRecord& record, BlobHandle* handle);
 
+  // Enter unbuffered state, only be called after collecting enough samples
+  // for compression dictionary
+  void EnterUnbuffered();
+
   // Returns non-ok iff some error has been detected.
   Status status() const { return status_; }
 
@@ -77,14 +82,9 @@ class BlobFileBuilder {
   //   compressed/written out as they fill up. From this state, call `Finish()`
   //   to complete the file (write meta-blocks, etc.), or `Abandon()` to delete
   //   the partially created file.
-  //
-  // - `kClosed`: This indicates either `Finish()` or `Abandon()` has been
-  //   called, so the table builder is no longer usable. We must be in this
-  //   state by the time the destructor runs.
   enum class BuilderState {
     kBuffered,
     kUnbuffered,
-    kClosed,
   };
   BuilderState builder_state_;
 

--- a/src/blob_file_builder.h
+++ b/src/blob_file_builder.h
@@ -58,11 +58,8 @@ class BlobFileBuilder {
     std::string key;  // original internal key
     BlobIndex original_blob_index;
     BlobIndex new_blob_index;
-    struct CachedData {
-      CachedData() : is_cached(false) {}
-      bool is_cached;
-      std::string value;
-    } cached_data;
+    bool has_value = false;
+    std::string value;
   };
   typedef autovector<std::unique_ptr<BlobRecordContext>> OutContexts;
 
@@ -80,8 +77,9 @@ class BlobFileBuilder {
   void Add(const BlobRecord& record, std::unique_ptr<BlobRecordContext> ctx,
            OutContexts* out_ctx);
 
-  // Cache the context passed in to prevent disorder issue
-  void CacheContext(std::unique_ptr<BlobRecordContext> ctx);
+  // AddSmall is used to prevent the disorder issue, small KV pairs and blob
+  // index block may be passed in here
+  void AddSmall(std::unique_ptr<BlobRecordContext> ctx);
 
   // Returns builder state
   BuilderState GetBuilderState() { return builder_state_; }

--- a/src/blob_file_builder.h
+++ b/src/blob_file_builder.h
@@ -3,6 +3,7 @@
 #include "blob_format.h"
 #include "table/meta_blocks.h"
 #include "titan/options.h"
+#include "util/autovector.h"
 #include "util/compression.h"
 #include "util/file_reader_writer.h"
 
@@ -53,13 +54,11 @@ class BlobFileBuilder {
     kUnbuffered,
   };
 
-  class BlobRecordContext {
-   public:
+  struct BlobRecordContext {
     std::string key;  // original internal key
     BlobIndex original_blob_index;
     BlobIndex new_blob_index;
-    class CachedData {
-     public:
+    struct CachedData {
       CachedData() : is_cached(false) {}
       bool is_cached;
       std::string value;

--- a/src/blob_file_builder.h
+++ b/src/blob_file_builder.h
@@ -116,8 +116,7 @@ class BlobFileBuilder {
   void EnterUnbuffered(OutContexts* out_ctx);
   void WriteHeader();
   void WriteRawBlock(const Slice& block, BlockHandle* handle);
-  void WriteCompressionDictBlock(MetaIndexBuilder* meta_index_builder,
-                                 BlockHandle* handle);
+  void WriteCompressionDictBlock(MetaIndexBuilder* meta_index_builder);
   void FlushSampleRecords(OutContexts* out_ctx);
   void WriteEncoderData(BlobHandle* handle);
 

--- a/src/blob_file_builder.h
+++ b/src/blob_file_builder.h
@@ -58,12 +58,12 @@ class BlobFileBuilder {
     std::string key;  // original internal key
     BlobIndex original_blob_index;
     BlobIndex new_blob_index;
-    class SmallKVContetx {
+    class CachedData {
      public:
-      SmallKVContetx() : is_small(false) {}
-      bool is_small;
+      CachedData() : is_cached(false) {}
+      bool is_cached;
       std::string value;
-    } small_kv_ctx;
+    } cached_data;
   };
   typedef autovector<std::unique_ptr<BlobRecordContext>> OutContexts;
 
@@ -81,9 +81,8 @@ class BlobFileBuilder {
   void Add(const BlobRecord& record, std::unique_ptr<BlobRecordContext> ctx,
            OutContexts* out_ctx);
 
-  // Cache small KV pair to prevent disorder issue
-  void CacheSmallKV(const BlobRecord& record,
-                    std::unique_ptr<BlobRecordContext> ctx);
+  // Cache the context passed in to prevent disorder issue
+  void CacheContext(std::unique_ptr<BlobRecordContext> ctx);
 
   // Returns builder state
   BuilderState GetBuilderState() { return builder_state_; }

--- a/src/blob_file_iterator.cc
+++ b/src/blob_file_iterator.cc
@@ -28,6 +28,10 @@ bool BlobFileIterator::Init() {
   }
   BlobFileHeader blob_file_header;
   status_ = blob_file_header.DecodeFrom(&slice);
+  if (blob_file_header.flags & BlobFileHeader::kHasUncompressionDictionary) {
+    status_ = Status::NotSupported(
+        "blob file with dictionary compression is not supported yet");
+  }
   if (!status_.ok()) {
     return false;
   }

--- a/src/blob_file_iterator_test.cc
+++ b/src/blob_file_iterator_test.cc
@@ -232,7 +232,7 @@ TEST_F(BlobFileIteratorTest, MergeIterator) {
     ASSERT_EQ(iter.key(), GenKey(i));
     ASSERT_EQ(iter.value(), GenValue(i));
     ASSERT_EQ(iter.GetBlobIndex().blob_handle,
-              key_indices[i].second->blob_handle);
+              key_indices[i - 1].second->blob_handle);
   }
   ASSERT_EQ(i, kMaxKeyNum);
 }

--- a/src/blob_file_iterator_test.cc
+++ b/src/blob_file_iterator_test.cc
@@ -87,12 +87,12 @@ class BlobFileIteratorTest : public testing::Test {
   void FinishBuilder(BlobFileBuilder::OutContexts& contexts) {
     BlobFileBuilder::OutContexts cur_contexts;
     Status s = builder_->Finish(&cur_contexts);
+    ASSERT_OK(s);
+    ASSERT_OK(builder_->status());
 
     for (size_t i = 0; i < cur_contexts.size(); i++) {
       contexts.emplace_back(std::move(cur_contexts[i]));
     }
-    ASSERT_OK(s);
-    ASSERT_OK(builder_->status());
   }
 
   void NewBlobFileIterator() {

--- a/src/blob_file_iterator_test.cc
+++ b/src/blob_file_iterator_test.cc
@@ -162,13 +162,14 @@ TEST_F(BlobFileIteratorTest, IterateForPrev) {
     ASSERT_EQ(blob_file_iterator_->Valid(), true);
     BlobIndex blob_index;
     blob_index = blob_file_iterator_->GetBlobIndex();
+    blob_handle = contexts[i]->new_blob_index.blob_handle;
     ASSERT_EQ(blob_handle, blob_index.blob_handle);
     ASSERT_EQ(GenKey(i), blob_file_iterator_->key());
     ASSERT_EQ(GenValue(i), blob_file_iterator_->value());
   }
 
   auto idx = Random::GetTLSInstance()->Uniform(n);
-  blob_handle = contexts[i]->new_blob_index.blob_handle;
+  blob_handle = contexts[idx]->new_blob_index.blob_handle;
   blob_file_iterator_->IterateForPrev(blob_handle.offset);
   ASSERT_OK(blob_file_iterator_->status());
   blob_file_iterator_->Next();
@@ -180,7 +181,7 @@ TEST_F(BlobFileIteratorTest, IterateForPrev) {
 
   while ((idx = Random::GetTLSInstance()->Uniform(n)) == 0)
     ;
-  blob_handle = contexts[i]->new_blob_index.blob_handle;
+  blob_handle = contexts[idx]->new_blob_index.blob_handle;
   blob_file_iterator_->IterateForPrev(blob_handle.offset - kRecordHeaderSize -
                                       1);
   ASSERT_OK(blob_file_iterator_->status());
@@ -188,10 +189,11 @@ TEST_F(BlobFileIteratorTest, IterateForPrev) {
   ASSERT_OK(blob_file_iterator_->status());
   ASSERT_TRUE(blob_file_iterator_->Valid());
   blob_index = blob_file_iterator_->GetBlobIndex();
+  blob_handle = contexts[idx - 1]->new_blob_index.blob_handle;
   ASSERT_EQ(blob_handle, blob_index.blob_handle);
 
   idx = Random::GetTLSInstance()->Uniform(n);
-  blob_handle = contexts[i]->new_blob_index.blob_handle;
+  blob_handle = contexts[idx]->new_blob_index.blob_handle;
   blob_file_iterator_->IterateForPrev(blob_handle.offset + 1);
   ASSERT_OK(blob_file_iterator_->status());
   blob_file_iterator_->Next();

--- a/src/blob_file_reader.cc
+++ b/src/blob_file_reader.cc
@@ -100,7 +100,6 @@ Status BlobFileReader::ReadHeader(
   if (!s.ok()) return s;
 
   s = DecodeInto(buffer, header);
-  if (!s.ok()) return s;
 
   return s;
 }

--- a/src/blob_file_reader.cc
+++ b/src/blob_file_reader.cc
@@ -8,10 +8,9 @@
 
 #include "file/filename.h"
 #include "test_util/sync_point.h"
+#include "titan_stats.h"
 #include "util/crc32c.h"
 #include "util/string_util.h"
-
-#include "titan_stats.h"
 
 namespace rocksdb {
 namespace titandb {
@@ -62,6 +61,12 @@ Status BlobFileReader::Open(const TitanCFOptions& options,
                             TitanStats* stats) {
   if (file_size < BlobFileFooter::kEncodedLength) {
     return Status::Corruption("file is too short to be a blob file");
+  }
+
+  if (options.blob_file_compression_options.enabled &&
+      options.blob_file_compression_options.max_dict_bytes > 0) {
+    return Status::NotSupported(
+        "blob file with dictionary compression is not supported yet");
   }
 
   FixedSlice<BlobFileFooter::kEncodedLength> buffer;

--- a/src/blob_file_reader.cc
+++ b/src/blob_file_reader.cc
@@ -64,7 +64,7 @@ Status BlobFileReader::Open(const TitanCFOptions& options,
   }
 
   BlobFileHeader header;
-  Status s = ReadHeader(&header, file);
+  Status s = ReadHeader(file, &header);
   if (!s.ok()) {
     return s;
   }
@@ -92,8 +92,8 @@ Status BlobFileReader::Open(const TitanCFOptions& options,
   return Status::OK();
 }
 
-Status BlobFileReader::ReadHeader(
-    BlobFileHeader* header, std::unique_ptr<RandomAccessFileReader>& file) {
+Status BlobFileReader::ReadHeader(std::unique_ptr<RandomAccessFileReader>& file,
+                                  BlobFileHeader* header) {
   FixedSlice<BlobFileHeader::kMaxEncodedLength> buffer;
   Status s =
       file->Read(0, BlobFileHeader::kMaxEncodedLength, &buffer, buffer.get());

--- a/src/blob_file_reader.h
+++ b/src/blob_file_reader.h
@@ -38,6 +38,8 @@ class BlobFileReader {
 
   Status ReadRecord(const BlobHandle& handle, BlobRecord* record,
                     OwnedSlice* buffer);
+  static Status ReadHeader(BlobFileHeader* header,
+                           std::unique_ptr<RandomAccessFileReader>& file);
 
   TitanCFOptions options_;
   std::unique_ptr<RandomAccessFileReader> file_;

--- a/src/blob_file_reader.h
+++ b/src/blob_file_reader.h
@@ -38,8 +38,8 @@ class BlobFileReader {
 
   Status ReadRecord(const BlobHandle& handle, BlobRecord* record,
                     OwnedSlice* buffer);
-  static Status ReadHeader(BlobFileHeader* header,
-                           std::unique_ptr<RandomAccessFileReader>& file);
+  static Status ReadHeader(std::unique_ptr<RandomAccessFileReader>& file,
+                           BlobFileHeader* header);
 
   TitanCFOptions options_;
   std::unique_ptr<RandomAccessFileReader> file_;

--- a/src/blob_file_test.cc
+++ b/src/blob_file_test.cc
@@ -103,7 +103,7 @@ class BlobFileTest : public testing::Test {
       expect.value = value;
       BlobRecord record;
       PinnableSlice buffer;
-      BlobHandle blob_handle = contexts[i]->index.blob_handle;
+      BlobHandle blob_handle = contexts[i]->new_blob_index.blob_handle;
       ASSERT_OK(cache.Get(ro, file_number_, file_size, blob_handle, &record,
                           &buffer));
       ASSERT_EQ(record, expect);
@@ -175,7 +175,7 @@ class BlobFileTest : public testing::Test {
       expect.value = value;
       BlobRecord record;
       PinnableSlice buffer;
-      BlobHandle blob_handle = contexts[i]->index.blob_handle;
+      BlobHandle blob_handle = contexts[i]->new_blob_index.blob_handle;
       ASSERT_OK(cache.Get(ro, file_number_, file_size, blob_handle, &record,
                           &buffer));
       ASSERT_EQ(record, expect);

--- a/src/blob_format.cc
+++ b/src/blob_format.cc
@@ -40,7 +40,8 @@ void BlobEncoder::EncodeRecord(const BlobRecord& record) {
 
   CompressionType compression;
   record.EncodeTo(&record_buffer_);
-  record_ = Compress(compression_info_, record_buffer_, &compressed_buffer_,
+
+  record_ = Compress(*compression_info_, record_buffer_, &compressed_buffer_,
                      &compression);
 
   assert(record_.size() < std::numeric_limits<uint32_t>::max());

--- a/src/blob_format.cc
+++ b/src/blob_format.cc
@@ -37,10 +37,10 @@ bool operator==(const BlobRecord& lhs, const BlobRecord& rhs) {
 void BlobEncoder::EncodeRecord(const BlobRecord& record) {
   record_buffer_.clear();
   record.EncodeTo(&record_buffer_);
-  EncodeString(record_buffer_);
+  EncodeSlice(record_buffer_);
 }
 
-void BlobEncoder::EncodeString(const Slice& record) {
+void BlobEncoder::EncodeSlice(const Slice& record) {
   compressed_buffer_.clear();
   CompressionType compression;
   record_ =

--- a/src/blob_format.cc
+++ b/src/blob_format.cc
@@ -40,11 +40,11 @@ void BlobEncoder::EncodeRecord(const BlobRecord& record) {
   EncodeString(record_buffer_);
 }
 
-void BlobEncoder::EncodeString(const std::string& record_str) {
+void BlobEncoder::EncodeString(const Slice& record) {
   compressed_buffer_.clear();
   CompressionType compression;
-  record_ = Compress(*compression_info_, record_str, &compressed_buffer_,
-                     &compression);
+  record_ =
+      Compress(*compression_info_, record, &compressed_buffer_, &compression);
 
   assert(record_.size() < std::numeric_limits<uint32_t>::max());
   EncodeFixed32(header_ + 4, static_cast<uint32_t>(record_.size()));

--- a/src/blob_format.cc
+++ b/src/blob_format.cc
@@ -36,12 +36,14 @@ bool operator==(const BlobRecord& lhs, const BlobRecord& rhs) {
 
 void BlobEncoder::EncodeRecord(const BlobRecord& record) {
   record_buffer_.clear();
-  compressed_buffer_.clear();
-
-  CompressionType compression;
   record.EncodeTo(&record_buffer_);
+  EncodeString(record_buffer_);
+}
 
-  record_ = Compress(*compression_info_, record_buffer_, &compressed_buffer_,
+void BlobEncoder::EncodeString(const std::string& record_str) {
+  compressed_buffer_.clear();
+  CompressionType compression;
+  record_ = Compress(*compression_info_, record_str, &compressed_buffer_,
                      &compression);
 
   assert(record_.size() < std::numeric_limits<uint32_t>::max());

--- a/src/blob_format.h
+++ b/src/blob_format.h
@@ -168,6 +168,9 @@ struct BlobIndex {
 struct MergeBlobIndex : public BlobIndex {
   uint64_t source_file_number{0};
   uint64_t source_file_offset{0};
+  // The `source_file_size` will not be encoded to string, just for rebuilding
+  // the original index
+  uint64_t source_file_size{0};
 
   void EncodeTo(std::string* dst) const;
   void EncodeToBase(std::string* dst) const;

--- a/src/blob_format.h
+++ b/src/blob_format.h
@@ -79,6 +79,7 @@ class BlobEncoder {
                     CompressionDict::GetEmptyDict()) {}
 
   void EncodeRecord(const BlobRecord& record);
+  void EncodeString(const std::string& record_str);
   void SetCompressionDict(const CompressionDict& compression_dict) {
     compression_info_.reset(new CompressionInfo(
         compression_opt_, compression_ctx_, compression_dict,

--- a/src/blob_format.h
+++ b/src/blob_format.h
@@ -312,6 +312,10 @@ class BlobFileMeta {
 // The header is mean to be compatible with header of BlobDB blob files, except
 // we use a different magic number.
 struct BlobFileHeader {
+  BlobFileHeader(const CompressionOptions& blob_file_compression_options) {
+    if (blob_file_compression_options.max_dict_bytes > 0)
+      flags |= kHasUncompressionDictionary;
+  };
   // The first 32bits from $(echo titandb/blob | sha1sum).
   static const uint32_t kHeaderMagicNumber = 0x2be0a614ul;
   static const uint32_t kVersion1 = 1;

--- a/src/blob_format.h
+++ b/src/blob_format.h
@@ -79,7 +79,7 @@ class BlobEncoder {
                     CompressionDict::GetEmptyDict()) {}
 
   void EncodeRecord(const BlobRecord& record);
-  void EncodeString(const Slice& record);
+  void EncodeSlice(const Slice& record);
   void SetCompressionDict(const CompressionDict& compression_dict) {
     compression_info_.reset(new CompressionInfo(
         compression_opt_, compression_ctx_, compression_dict,

--- a/src/blob_format.h
+++ b/src/blob_format.h
@@ -61,23 +61,28 @@ struct BlobRecord {
 
 class BlobEncoder {
  public:
+  BlobEncoder(CompressionType compression, CompressionOptions compression_opt,
+              const CompressionDict& compression_dict)
+      : compression_opt_(compression_opt),
+        compression_ctx_(compression),
+        compression_info_(new CompressionInfo(compression_opt, compression_ctx_,
+                                              compression_dict, compression,
+                                              0 /*sample_for_compression*/)) {}
+  BlobEncoder(CompressionType compression)
+      : BlobEncoder(compression, CompressionOptions(),
+                    CompressionDict::GetEmptyDict()) {}
   BlobEncoder(CompressionType compression,
               const CompressionDict& compression_dict)
-      : compression_ctx_(compression),
-        compression_info_(new CompressionInfo(
-            compression_opt_, compression_ctx_, compression_dict, compression,
-            0 /*sample_for_compression*/)) {}
-  BlobEncoder(CompressionType compression)
-      : BlobEncoder(compression, CompressionDict::GetEmptyDict()) {}
+      : BlobEncoder(compression, CompressionOptions(), compression_dict) {}
+  BlobEncoder(CompressionType compression, CompressionOptions compression_opt)
+      : BlobEncoder(compression, compression_opt,
+                    CompressionDict::GetEmptyDict()) {}
 
   void EncodeRecord(const BlobRecord& record);
   void SetCompressionDict(const CompressionDict& compression_dict) {
     compression_info_.reset(new CompressionInfo(
         compression_opt_, compression_ctx_, compression_dict,
         compression_info_->type(), compression_info_->SampleForCompression()));
-  }
-  Slice GetCompressionDict() const {
-    return compression_info_->dict().GetRawDict();
   }
 
   Slice GetHeader() const { return Slice(header_, sizeof(header_)); }

--- a/src/blob_format.h
+++ b/src/blob_format.h
@@ -168,9 +168,6 @@ struct BlobIndex {
 struct MergeBlobIndex : public BlobIndex {
   uint64_t source_file_number{0};
   uint64_t source_file_offset{0};
-  // The `source_file_size` will not be encoded to string, just for rebuilding
-  // the original index
-  uint64_t source_file_size{0};
 
   void EncodeTo(std::string* dst) const;
   void EncodeToBase(std::string* dst) const;

--- a/src/blob_format.h
+++ b/src/blob_format.h
@@ -321,10 +321,6 @@ class BlobFileMeta {
 // The header is mean to be compatible with header of BlobDB blob files, except
 // we use a different magic number.
 struct BlobFileHeader {
-  BlobFileHeader(const CompressionOptions& blob_file_compression_options) {
-    if (blob_file_compression_options.max_dict_bytes > 0)
-      flags |= kHasUncompressionDictionary;
-  };
   // The first 32bits from $(echo titandb/blob | sha1sum).
   static const uint32_t kHeaderMagicNumber = 0x2be0a614ul;
   static const uint32_t kVersion1 = 1;

--- a/src/blob_format.h
+++ b/src/blob_format.h
@@ -79,7 +79,7 @@ class BlobEncoder {
                     CompressionDict::GetEmptyDict()) {}
 
   void EncodeRecord(const BlobRecord& record);
-  void EncodeString(const std::string& record_str);
+  void EncodeString(const Slice& record);
   void SetCompressionDict(const CompressionDict& compression_dict) {
     compression_info_.reset(new CompressionInfo(
         compression_opt_, compression_ctx_, compression_dict,

--- a/src/blob_format.h
+++ b/src/blob_format.h
@@ -368,10 +368,6 @@ struct BlobFileFooter {
 
   BlockHandle meta_index_handle{BlockHandle::NullBlockHandle()};
 
-  // Points to a uncompression dictionary (which is also pointed to by the meta
-  // index) when `kHasUncompressionDictionary` is set in the header.
-  BlockHandle uncompression_dict_handle{BlockHandle::NullBlockHandle()};
-
   void EncodeTo(std::string* dst) const;
   Status DecodeFrom(Slice* src);
 

--- a/src/blob_format.h
+++ b/src/blob_format.h
@@ -62,27 +62,29 @@ struct BlobRecord {
 class BlobEncoder {
  public:
   BlobEncoder(CompressionType compression, CompressionOptions compression_opt,
-              const CompressionDict& compression_dict)
+              const CompressionDict* compression_dict)
       : compression_opt_(compression_opt),
         compression_ctx_(compression),
-        compression_info_(new CompressionInfo(compression_opt, compression_ctx_,
-                                              compression_dict, compression,
-                                              0 /*sample_for_compression*/)) {}
+        compression_dict_(compression_dict),
+        compression_info_(new CompressionInfo(
+            compression_opt_, compression_ctx_, *compression_dict_, compression,
+            0 /*sample_for_compression*/)) {}
   BlobEncoder(CompressionType compression)
       : BlobEncoder(compression, CompressionOptions(),
-                    CompressionDict::GetEmptyDict()) {}
+                    &CompressionDict::GetEmptyDict()) {}
   BlobEncoder(CompressionType compression,
-              const CompressionDict& compression_dict)
+              const CompressionDict* compression_dict)
       : BlobEncoder(compression, CompressionOptions(), compression_dict) {}
   BlobEncoder(CompressionType compression, CompressionOptions compression_opt)
       : BlobEncoder(compression, compression_opt,
-                    CompressionDict::GetEmptyDict()) {}
+                    &CompressionDict::GetEmptyDict()) {}
 
   void EncodeRecord(const BlobRecord& record);
   void EncodeSlice(const Slice& record);
-  void SetCompressionDict(const CompressionDict& compression_dict) {
+  void SetCompressionDict(const CompressionDict* compression_dict) {
+    compression_dict_ = compression_dict;
     compression_info_.reset(new CompressionInfo(
-        compression_opt_, compression_ctx_, compression_dict,
+        compression_opt_, compression_ctx_, *compression_dict_,
         compression_info_->type(), compression_info_->SampleForCompression()));
   }
 
@@ -98,6 +100,7 @@ class BlobEncoder {
   std::string compressed_buffer_;
   CompressionOptions compression_opt_;
   CompressionContext compression_ctx_;
+  const CompressionDict* compression_dict_;
   std::unique_ptr<CompressionInfo> compression_info_;
 };
 

--- a/src/blob_format_test.cc
+++ b/src/blob_format_test.cc
@@ -1,6 +1,6 @@
-#include "test_util/testharness.h"
-
 #include "blob_format.h"
+
+#include "test_util/testharness.h"
 #include "testutil.h"
 #include "util.h"
 
@@ -118,7 +118,7 @@ TEST(BlobFormatTest, BlobCompressionZSTD) {
   CompressionDict compression_dict(dict, kZSTD, 10);
   UncompressionDict uncompression_dict(dict, true);
 
-  BlobEncoder encoder(kZSTD, compression_dict);
+  BlobEncoder encoder(kZSTD, &compression_dict);
   BlobDecoder decoder(uncompression_dict);
 
   BlobRecord record;

--- a/src/blob_gc_job.cc
+++ b/src/blob_gc_job.cc
@@ -267,7 +267,7 @@ Status BlobGCJob::DoRunGC() {
 
 void BlobGCJob::BatchWriteNewIndices(BlobIndices& key_indices, Status* s) {
   auto* cfh = blob_gc_->column_family_handle();
-  for (const std::pair<Slice, std::unique_ptr<BlobIndex>>& key_index :
+  for (const std::pair<std::string, std::unique_ptr<BlobIndex>>& key_index :
        key_indices) {
     MergeBlobIndex* new_blob_index =
         static_cast<MergeBlobIndex*>(key_index.second.get());
@@ -279,7 +279,7 @@ void BlobGCJob::BatchWriteNewIndices(BlobIndices& key_indices, Status* s) {
     if (!gc_merge_rewrite_) {
       new_blob_index->EncodeToBase(&index_entry);
       // Store WriteBatch for rewriting new Key-Index pairs to LSM
-      GarbageCollectionWriteCallback callback(cfh, key_index.first.ToString(),
+      GarbageCollectionWriteCallback callback(cfh, std::string(key_index.first),
                                               std::move(blob_index));
       callback.value = index_entry;
       rewrite_batches_.emplace_back(

--- a/src/blob_gc_job.cc
+++ b/src/blob_gc_job.cc
@@ -232,6 +232,8 @@ Status BlobGCJob::DoRunGC() {
     // blob index's size is counted in `RewriteValidKeyToLSM`
     metrics_.gc_bytes_written += blob_record.size();
 
+    // BlobRecordContext require key to be an internal key. We encode key to
+    // internal key in spite we only need the user key.
     std::unique_ptr<BlobFileBuilder::BlobRecordContext> ctx(
         new BlobFileBuilder::BlobRecordContext);
     InternalKey ikey(blob_record.key, 1, kTypeValue);

--- a/src/blob_gc_job.h
+++ b/src/blob_gc_job.h
@@ -90,8 +90,7 @@ class BlobGCJob {
   uint64_t io_bytes_written_ = 0;
 
   Status DoRunGC();
-  void BatchWriteNewIndices(BlobFileBuilder::BlobRecordContexts &contexts,
-                            Status *s);
+  void BatchWriteNewIndices(BlobFileBuilder::OutContexts &contexts, Status *s);
   Status BuildIterator(std::unique_ptr<BlobFileMergeIterator> *result);
   Status DiscardEntry(const Slice &key, const BlobIndex &blob_index,
                       bool *discardable);

--- a/src/blob_gc_job.h
+++ b/src/blob_gc_job.h
@@ -90,9 +90,10 @@ class BlobGCJob {
   uint64_t io_bytes_written_ = 0;
 
   Status DoRunGC();
-  Status BuildIterator(std::unique_ptr<BlobFileMergeIterator>* result);
-  Status DiscardEntry(const Slice& key, const BlobIndex& blob_index,
-                      bool* discardable);
+  void BatchWriteNewIndices(BlobIndices &key_indices, Status *s);
+  Status BuildIterator(std::unique_ptr<BlobFileMergeIterator> *result);
+  Status DiscardEntry(const Slice &key, const BlobIndex &blob_index,
+                      bool *discardable);
   Status InstallOutputBlobFiles();
   Status RewriteValidKeyToLSM();
   Status DeleteInputBlobFiles();

--- a/src/blob_gc_job.h
+++ b/src/blob_gc_job.h
@@ -38,10 +38,6 @@ class BlobGCJob {
   Status Finish();
 
  private:
-  class BlobGCJobRecordContext : public BlobFileBuilder::BlobRecordContext {
-   public:
-    BlobIndex original_index;
-  };
   class GarbageCollectionWriteCallback;
   friend class BlobGCJobTest;
 

--- a/src/blob_gc_job.h
+++ b/src/blob_gc_job.h
@@ -38,6 +38,10 @@ class BlobGCJob {
   Status Finish();
 
  private:
+  class BlobGCJobRecordContext : public BlobFileBuilder::BlobRecordContext {
+   public:
+    BlobIndex original_index;
+  };
   class GarbageCollectionWriteCallback;
   friend class BlobGCJobTest;
 
@@ -90,7 +94,8 @@ class BlobGCJob {
   uint64_t io_bytes_written_ = 0;
 
   Status DoRunGC();
-  void BatchWriteNewIndices(BlobIndices &key_indices, Status *s);
+  void BatchWriteNewIndices(BlobFileBuilder::BlobRecordContexts &contexts,
+                            Status *s);
   Status BuildIterator(std::unique_ptr<BlobFileMergeIterator> *result);
   Status DiscardEntry(const Slice &key, const BlobIndex &blob_index,
                       bool *discardable);

--- a/src/blob_gc_job_test.cc
+++ b/src/blob_gc_job_test.cc
@@ -1,9 +1,9 @@
-#include "rocksdb/convenience.h"
-#include "test_util/testharness.h"
-
 #include "blob_gc_job.h"
+
 #include "blob_gc_picker.h"
 #include "db_impl.h"
+#include "rocksdb/convenience.h"
+#include "test_util/testharness.h"
 
 namespace rocksdb {
 namespace titandb {

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -143,7 +143,7 @@ BlobIndices TitanTableBuilder::AddBlob(const BlobRecord& record) {
 }
 
 void TitanTableBuilder::BatchInsertIndices(const BlobIndices& key_indices) {
-  for (const std::pair<Slice, std::unique_ptr<BlobIndex>>& key_index :
+  for (const std::pair<std::string, std::unique_ptr<BlobIndex>>& key_index :
        key_indices) {
     RecordTick(statistics(stats_), TITAN_BLOB_FILE_BYTES_WRITTEN,
                key_index.second->blob_handle.size);

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -60,7 +60,7 @@ void TitanTableBuilder::Add(const Slice& key, const Slice& value) {
     record.key = ikey.user_key;
     record.value = value;
     BlobFileBuilder::BlobRecordContexts contexts = AddBlob(record, ikey);
-    BatchInsertIndices(contexts);
+    AddToBaseTable(contexts);
 
     UpdateIOBytes(prev_bytes_read, prev_bytes_written, &io_bytes_read_,
                   &io_bytes_written_);
@@ -98,7 +98,7 @@ void TitanTableBuilder::Add(const Slice& key, const Slice& value) {
         blob_record.value = record.value;
         BlobFileBuilder::BlobRecordContexts contexts =
             AddBlob(blob_record, ikey);
-        BatchInsertIndices(contexts);
+        AddToBaseTable(contexts);
         UpdateIOBytes(prev_bytes_read, prev_bytes_written, &io_bytes_read_,
                       &io_bytes_written_);
         if (ok()) return;
@@ -147,7 +147,7 @@ BlobFileBuilder::BlobRecordContexts TitanTableBuilder::AddBlob(
   return blob_builder_->Add(record, std::move(ctx));
 }
 
-void TitanTableBuilder::BatchInsertIndices(
+void TitanTableBuilder::AddToBaseTable(
     const BlobFileBuilder::BlobRecordContexts& contexts) {
   for (const std::unique_ptr<BlobFileBuilder::BlobRecordContext>& base_ctx :
        contexts) {
@@ -175,7 +175,7 @@ void TitanTableBuilder::FinishBlobFile() {
     SavePrevIOBytes(&prev_bytes_read, &prev_bytes_written);
     Status s;
     BlobFileBuilder::BlobRecordContexts contexts = blob_builder_->Finish(&s);
-    BatchInsertIndices(contexts);
+    AddToBaseTable(contexts);
 
     UpdateIOBytes(prev_bytes_read, prev_bytes_written, &io_bytes_read_,
                   &io_bytes_written_);

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -215,8 +215,8 @@ Status TitanTableBuilder::status() const {
 }
 
 Status TitanTableBuilder::Finish() {
-  base_builder_->Finish();
   FinishBlobFile();
+  base_builder_->Finish();
   status_ = blob_manager_->BatchFinishFiles(cf_id_, finished_blobs_);
   if (!status_.ok()) {
     ROCKS_LOG_ERROR(db_options_.info_log,

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -125,8 +125,9 @@ void TitanTableBuilder::AddBlob(const BlobRecord& record,
   bool is_small_kv = ikey.type == kTypeValue &&
                      record.value.size() < cf_options_.min_blob_size;
 
-  // Only if this record is a small KV pair, can the blob_builder_ has no
-  // writer, otherwise should setup a writer
+  // If we only write small KV pairs with dictionary compression, it may cause
+  // unnecessary blob file generation and fail the `NonBlob` test, so we allow
+  // nullable writer in this case, otherwise, the writer must not be nullptr.
   if (!blob_builder_->HasFileWriter() && !is_small_kv) {
     status_ = blob_manager_->NewFile(&blob_handle_);
     if (!ok()) return;

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -221,7 +221,7 @@ void TitanTableBuilder::FinishBlobFile() {
                   &io_bytes_written_);
     AddToBaseTable(contexts, true);
 
-    if (ok()) {
+    if (s.ok() && ok()) {
       ROCKS_LOG_INFO(db_options_.info_log,
                      "Titan table builder finish output file %" PRIu64 ".",
                      blob_handle_->GetNumber());

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -82,11 +82,8 @@ void TitanTableBuilder::Add(const Slice& key, const Slice& value) {
       return;
     } else {
       // We write to blob file and insert index
-      BlobRecord record;
-      record.key = ikey.user_key;
-      record.value = value;
       BlobFileBuilder::OutContexts contexts;
-      AddBlob(record, ikey, &contexts);
+      AddBlob(ikey, value, &contexts);
       UpdateIOBytes(prev_bytes_read, prev_bytes_written, &io_bytes_read_,
                     &io_bytes_written_);
       AddToBaseTable(contexts);
@@ -113,11 +110,8 @@ void TitanTableBuilder::Add(const Slice& key, const Slice& value) {
       // doing level merge.
       if (get_status.ok()) {
         std::string index_value;
-        BlobRecord blob_record;
-        blob_record.key = ikey.user_key;
-        blob_record.value = record.value;
         BlobFileBuilder::OutContexts contexts;
-        AddBlob(blob_record, ikey, &contexts);
+        AddBlob(ikey, record.value, &contexts);
         UpdateIOBytes(prev_bytes_read, prev_bytes_written, &io_bytes_read_,
                       &io_bytes_written_);
         AddToBaseTable(contexts);
@@ -143,10 +137,15 @@ void TitanTableBuilder::Add(const Slice& key, const Slice& value) {
   }
 }
 
-void TitanTableBuilder::AddBlob(const BlobRecord& record,
-                                const ParsedInternalKey& ikey,
+void TitanTableBuilder::AddBlob(const ParsedInternalKey& ikey,
+                                const Slice& value,
                                 BlobFileBuilder::OutContexts* contexts) {
   if (!ok()) return;
+
+  BlobRecord record;
+  record.key = ikey.user_key;
+  record.value = value;
+
   StopWatch write_sw(db_options_.env, statistics(stats_),
                      TITAN_BLOB_FILE_WRITE_MICROS);
 

--- a/src/table_builder.h
+++ b/src/table_builder.h
@@ -53,7 +53,8 @@ class TitanTableBuilder : public TableBuilder {
   BlobFileBuilder::BlobRecordContexts AddBlob(const BlobRecord& record,
                                               const ParsedInternalKey& ikey);
 
-  void AddToBaseTable(const BlobFileBuilder::BlobRecordContexts& contexts);
+  void AddToBaseTable(const BlobFileBuilder::BlobRecordContexts& contexts,
+                      bool finishing = false);
 
   bool ShouldMerge(const std::shared_ptr<BlobFileMeta>& file);
 

--- a/src/table_builder.h
+++ b/src/table_builder.h
@@ -46,13 +46,18 @@ class TitanTableBuilder : public TableBuilder {
   TableProperties GetTableProperties() const override;
 
  private:
+  class RecordContext : public BlobFileBuilder::BlobRecordContext {
+   public:
+    ParsedInternalKey ikey;
+  };
   friend class TableBuilderTest;
 
   bool ok() const { return status().ok(); }
 
-  BlobIndices AddBlob(const BlobRecord& record);
+  BlobFileBuilder::BlobRecordContexts AddBlob(const BlobRecord& record,
+                                              const ParsedInternalKey& ikey);
 
-  void BatchInsertIndices(const BlobIndices& key_indices);
+  void BatchInsertIndices(const BlobFileBuilder::BlobRecordContexts& contexts);
 
   bool ShouldMerge(const std::shared_ptr<BlobFileMeta>& file);
 

--- a/src/table_builder.h
+++ b/src/table_builder.h
@@ -57,7 +57,7 @@ class TitanTableBuilder : public TableBuilder {
   BlobFileBuilder::BlobRecordContexts AddBlob(const BlobRecord& record,
                                               const ParsedInternalKey& ikey);
 
-  void BatchInsertIndices(const BlobFileBuilder::BlobRecordContexts& contexts);
+  void AddToBaseTable(const BlobFileBuilder::BlobRecordContexts& contexts);
 
   bool ShouldMerge(const std::shared_ptr<BlobFileMeta>& file);
 

--- a/src/table_builder.h
+++ b/src/table_builder.h
@@ -1,10 +1,9 @@
 #pragma once
 
-#include "rocksdb/types.h"
-
 #include "blob_file_builder.h"
 #include "blob_file_manager.h"
 #include "blob_file_set.h"
+#include "rocksdb/types.h"
 #include "table/table_builder.h"
 #include "titan/options.h"
 #include "titan_stats.h"
@@ -51,7 +50,9 @@ class TitanTableBuilder : public TableBuilder {
 
   bool ok() const { return status().ok(); }
 
-  void AddBlob(const Slice& key, const Slice& value, std::string* index_value);
+  BlobIndices AddBlob(const BlobRecord& record);
+
+  void BatchInsertIndices(const BlobIndices& key_indices);
 
   bool ShouldMerge(const std::shared_ptr<BlobFileMeta>& file);
 

--- a/src/table_builder.h
+++ b/src/table_builder.h
@@ -46,10 +46,6 @@ class TitanTableBuilder : public TableBuilder {
   TableProperties GetTableProperties() const override;
 
  private:
-  class RecordContext : public BlobFileBuilder::BlobRecordContext {
-   public:
-    ParsedInternalKey ikey;
-  };
   friend class TableBuilderTest;
 
   bool ok() const { return status().ok(); }

--- a/src/table_builder.h
+++ b/src/table_builder.h
@@ -50,10 +50,10 @@ class TitanTableBuilder : public TableBuilder {
 
   bool ok() const { return status().ok(); }
 
-  BlobFileBuilder::BlobRecordContexts AddBlob(const BlobRecord& record,
-                                              const ParsedInternalKey& ikey);
+  void AddBlob(const BlobRecord& record, const ParsedInternalKey& ikey,
+               BlobFileBuilder::OutContexts* contexts);
 
-  void AddToBaseTable(const BlobFileBuilder::BlobRecordContexts& contexts,
+  void AddToBaseTable(const BlobFileBuilder::OutContexts& contexts,
                       bool finishing = false);
 
   bool ShouldMerge(const std::shared_ptr<BlobFileMeta>& file);

--- a/src/table_builder.h
+++ b/src/table_builder.h
@@ -50,6 +50,14 @@ class TitanTableBuilder : public TableBuilder {
 
   bool ok() const { return status().ok(); }
 
+  bool builder_unbuffered() const {
+    return !blob_builder_ || blob_builder_->GetBuilderState() ==
+                                 BlobFileBuilder::BuilderState::kUnbuffered;
+  }
+
+  std::unique_ptr<BlobFileBuilder::BlobRecordContext> NewCachedRecordContext(
+      const ParsedInternalKey& ikey, const Slice& value);
+
   void AddBlob(const BlobRecord& record, const ParsedInternalKey& ikey,
                BlobFileBuilder::OutContexts* contexts);
 

--- a/src/table_builder.h
+++ b/src/table_builder.h
@@ -58,11 +58,9 @@ class TitanTableBuilder : public TableBuilder {
   std::unique_ptr<BlobFileBuilder::BlobRecordContext> NewCachedRecordContext(
       const ParsedInternalKey& ikey, const Slice& value);
 
-  void AddBlob(const ParsedInternalKey& ikey, const Slice& value,
-               BlobFileBuilder::OutContexts* contexts);
+  void AddBlob(const ParsedInternalKey& ikey, const Slice& value);
 
-  void AddToBaseTable(const BlobFileBuilder::OutContexts& contexts,
-                      bool finishing = false);
+  void AddToBaseTable(const BlobFileBuilder::OutContexts& contexts);
 
   bool ShouldMerge(const std::shared_ptr<BlobFileMeta>& file);
 

--- a/src/table_builder.h
+++ b/src/table_builder.h
@@ -58,7 +58,7 @@ class TitanTableBuilder : public TableBuilder {
   std::unique_ptr<BlobFileBuilder::BlobRecordContext> NewCachedRecordContext(
       const ParsedInternalKey& ikey, const Slice& value);
 
-  void AddBlob(const BlobRecord& record, const ParsedInternalKey& ikey,
+  void AddBlob(const ParsedInternalKey& ikey, const Slice& value,
                BlobFileBuilder::OutContexts* contexts);
 
   void AddToBaseTable(const BlobFileBuilder::OutContexts& contexts,

--- a/src/table_builder_test.cc
+++ b/src/table_builder_test.cc
@@ -403,6 +403,67 @@ TEST_F(TableBuilderTest, DictCompress) {
 #endif
 }
 
+TEST_F(TableBuilderTest, DictCompressDisorder) {
+#if ZSTD_VERSION_NUMBER >= 10103
+  CompressionOptions compression_opts;
+  compression_opts.enabled = true;
+  compression_opts.max_dict_bytes = 4000;
+  cf_options_.blob_file_compression_options = compression_opts;
+  cf_options_.compression = kZSTD;
+
+  table_factory_.reset(new TitanTableFactory(
+      db_options_, cf_options_, db_impl_.get(), blob_manager_, &mutex_,
+      blob_file_set_.get(), nullptr));
+
+  std::unique_ptr<WritableFileWriter> base_file;
+  NewBaseFileWriter(&base_file);
+  std::unique_ptr<TableBuilder> table_builder;
+  NewTableBuilder(base_file.get(), &table_builder);
+
+  // Build a base table and a blob file.
+  const int n = 100;
+  for (char i = 0; i < n; i++) {
+    std::string key(1, i);
+    InternalKey ikey(key, 1, kTypeValue);
+    std::string value;
+    if (i % 2 == 0) {
+      value = std::string(1, i);
+    } else {
+      value = std::string(kMinBlobSize, i);
+    }
+    table_builder->Add(ikey.Encode(), value);
+  }
+  ASSERT_OK(table_builder->Finish());
+  ASSERT_OK(base_file->Sync(true));
+  ASSERT_OK(base_file->Close());
+  std::unique_ptr<TableReader> base_reader;
+  NewTableReader(base_name_, &base_reader);
+
+  ReadOptions ro;
+  std::unique_ptr<InternalIterator> iter;
+  iter.reset(base_reader->NewIterator(ro, nullptr /*prefix_extractor*/,
+                                      nullptr /*arena*/, false /*skip_filters*/,
+                                      TableReaderCaller::kUncategorized));
+  iter->SeekToFirst();
+  for (char i = 0; i < n; i++) {
+    ASSERT_TRUE(iter->Valid());
+    std::string key(1, i);
+    ParsedInternalKey ikey;
+    ASSERT_TRUE(ParseInternalKey(iter->key(), &ikey));
+    // check order
+    ASSERT_EQ(ikey.user_key, key);
+    if (i % 2 == 0) {
+      ASSERT_EQ(ikey.type, kTypeValue);
+      ASSERT_EQ(iter->value(), std::string(1, i));
+    } else {
+      ASSERT_EQ(ikey.type, kTypeBlobIndex);
+      // TODO: reading is not implmented yet
+    }
+    iter->Next();
+  }
+#endif
+}
+
 TEST_F(TableBuilderTest, NoBlob) {
   std::unique_ptr<WritableFileWriter> base_file;
   NewBaseFileWriter(&base_file);

--- a/src/table_builder_test.cc
+++ b/src/table_builder_test.cc
@@ -360,6 +360,7 @@ TEST_F(TableBuilderTest, Basic) {
 }
 
 TEST_F(TableBuilderTest, DictCompress) {
+#if ZSTD_VERSION_NUMBER >= 10103
   CompressionOptions compression_opts;
   compression_opts.enabled = true;
   compression_opts.max_dict_bytes = 4000;
@@ -399,6 +400,7 @@ TEST_F(TableBuilderTest, DictCompress) {
   Status stat = BlobFileReader::Open(cf_options_, std::move(file), file_size,
                                      &blob_reader, nullptr);
   assert(stat.code() == Status::kNotSupported);
+#endif
 }
 
 TEST_F(TableBuilderTest, NoBlob) {

--- a/src/table_builder_test.cc
+++ b/src/table_builder_test.cc
@@ -245,6 +245,13 @@ class TableBuilderTest : public testing::Test {
                        std::unique_ptr<TableBuilder>* result,
                        int target_level = 0) {
     CompressionOptions compression_opts;
+    NewTableBuilder(file, result, compression_opts, target_level);
+  }
+
+  void NewTableBuilder(WritableFileWriter* file,
+                       std::unique_ptr<TableBuilder>* result,
+                       CompressionOptions compression_opts,
+                       int target_level = 0) {
     TableBuilderOptions options(cf_ioptions_, cf_moptions_,
                                 cf_ioptions_.internal_comparator, &collectors_,
                                 kNoCompression, 0 /*sample_for_compression*/,
@@ -671,6 +678,103 @@ TEST_F(TableBuilderTest, LevelMerge) {
   }
 
   env_->DeleteFile(second_base_name);
+}
+
+// Write blob index, to test key order is correct with dictionary compression
+TEST_F(TableBuilderTest, LevelMergeWithDictCompressDisorder) {
+#if ZSTD_VERSION_NUMBER >= 10103
+  cf_options_.level_merge = true;
+  table_factory_.reset(new TitanTableFactory(
+      db_options_, cf_options_, db_impl_.get(), blob_manager_, &mutex_,
+      blob_file_set_.get(), nullptr));
+
+  std::unique_ptr<WritableFileWriter> base_file;
+  NewBaseFileWriter(&base_file);
+  std::unique_ptr<TableBuilder> table_builder;
+  NewTableBuilder(base_file.get(), &table_builder);
+
+  // Generate level 0 sst with blob file
+  int n = 100;
+  for (unsigned char i = 0; i < n; i++) {
+    if (i % 2 == 0) {
+      // key: 0, 2, 4, 6 ..98
+      std::string key(1, i);
+      InternalKey ikey(key, 1, kTypeValue);
+      std::string value(kMinBlobSize, i);
+      table_builder->Add(ikey.Encode(), value);
+    } else {
+      // key: 1, 3, 5, ..99
+      std::string key(1, i);
+      InternalKey ikey(key, 1, kTypeValue);
+      std::string value = std::string(1, i);
+      table_builder->Add(ikey.Encode(), value);
+    }
+  }
+  ASSERT_OK(table_builder->Finish());
+  ASSERT_OK(base_file->Sync(true));
+  ASSERT_OK(base_file->Close());
+
+  std::unique_ptr<TableReader> base_reader;
+  NewTableReader(base_name_, &base_reader);
+  ReadOptions ro;
+  std::unique_ptr<InternalIterator> first_iter;
+  first_iter.reset(base_reader->NewIterator(
+      ro, nullptr /*prefix_extractor*/, nullptr /*arena*/,
+      false /*skip_filters*/, TableReaderCaller::kUncategorized));
+
+  // Base file of last level sst
+  std::string second_base_name = base_name_ + "second";
+  NewFileWriter(second_base_name, &base_file);
+
+  CompressionOptions compression_opts;
+  compression_opts.enabled = true;
+  compression_opts.max_dict_bytes = 4000;
+  cf_options_.blob_file_compression_options = compression_opts;
+  cf_options_.compression = kZSTD;
+
+  NewTableBuilder(base_file.get(), &table_builder, compression_opts,
+                  cf_options_.num_levels - 1);
+
+  first_iter->SeekToFirst();
+  // compact data from level0 to level1
+  for (unsigned char i = 0; i < n; i++) {
+    ASSERT_TRUE(first_iter->Valid());
+    table_builder->Add(first_iter->key(), first_iter->value());
+    first_iter->Next();
+  }
+  ASSERT_OK(table_builder->Finish());
+  ASSERT_OK(base_file->Sync(true));
+  ASSERT_OK(base_file->Close());
+
+  std::unique_ptr<TableReader> second_base_reader;
+  NewTableReader(second_base_name, &second_base_reader);
+  std::unique_ptr<InternalIterator> second_iter;
+  second_iter.reset(second_base_reader->NewIterator(
+      ro, nullptr /*prefix_extractor*/, nullptr /*arena*/,
+      false /*skip_filters*/, TableReaderCaller::kUncategorized));
+
+  first_iter->SeekToFirst();
+  second_iter->SeekToFirst();
+  // check orders of keys
+  for (unsigned char i = 0; i < n; i++) {
+    ASSERT_TRUE(second_iter->Valid());
+
+    ASSERT_TRUE(first_iter->Valid());
+
+    // Compare sst key
+    ParsedInternalKey first_ikey, second_ikey;
+    ASSERT_TRUE(ParseInternalKey(first_iter->key(), &first_ikey));
+    ASSERT_TRUE(ParseInternalKey(first_iter->key(), &second_ikey));
+    ASSERT_EQ(first_ikey.type, second_ikey.type);
+    ASSERT_EQ(first_ikey.user_key, second_ikey.user_key);
+    // TODO: Compare blob records, need to implement decompression first
+
+    first_iter->Next();
+    second_iter->Next();
+  }
+
+  env_->DeleteFile(second_base_name);
+#endif
 }
 
 }  // namespace titandb

--- a/tools/titandb_stress.cc
+++ b/tools/titandb_stress.cc
@@ -2953,7 +2953,7 @@ class StressTest {
                   1024 * 1024 * 1024;
             }
             fprintf(stdout,
-                    "Create Titan column family %s with min_blob_size %lu\n",
+                    "Create Titan column family %s with min_blob_size %llu\n",
                     cfd.name.c_str(),
                     titan_cf_descriptors.back().options.min_blob_size);
           }
@@ -3237,7 +3237,7 @@ class NonBatchedOpsStressTest : public StressTest {
               tmp.back().options.min_blob_size = 1024 * 1024 * 1024;
             }
             fprintf(stdout,
-                    "recreate Titan column family %s with min_blob_size %lu\n",
+                    "recreate Titan column family %s with min_blob_size %llu\n",
                     new_name.c_str(), tmp.back().options.min_blob_size);
           }
           std::vector<ColumnFamilyHandle*> result;

--- a/tools/titandb_stress.cc
+++ b/tools/titandb_stress.cc
@@ -2953,7 +2953,8 @@ class StressTest {
                   1024 * 1024 * 1024;
             }
             fprintf(stdout,
-                    "Create Titan column family %s with min_blob_size %llu\n",
+                    "Create Titan column family %s with min_blob_size %" PRIu64
+                    "\n",
                     cfd.name.c_str(),
                     titan_cf_descriptors.back().options.min_blob_size);
           }
@@ -3236,9 +3237,11 @@ class NonBatchedOpsStressTest : public StressTest {
             if (new_column_family_name_ % 2 == 0) {
               tmp.back().options.min_blob_size = 1024 * 1024 * 1024;
             }
-            fprintf(stdout,
-                    "recreate Titan column family %s with min_blob_size %llu\n",
-                    new_name.c_str(), tmp.back().options.min_blob_size);
+            fprintf(
+                stdout,
+                "recreate Titan column family %s with min_blob_size %" PRIu64
+                "\n",
+                new_name.c_str(), tmp.back().options.min_blob_size);
           }
           std::vector<ColumnFamilyHandle*> result;
           s = tdb->CreateColumnFamilies(tmp, &result);


### PR DESCRIPTION
Fixes #118

Briefly I've done following things:
- add compression options in TitanCFOptions
- set flags in header when there is compression dictionary
- add some members(states, sample data, etc.) in BlobFileBuilder for dictionary compression logic
- write the dictionary in meta blocks, when dictionary compression is enabled
- refactor BlobEncoder to support dictionary update

currently for decoding
- update BlobFileReader and BlobFileIterator to return Status::NotSupported if a blob file come with dictionary compression.
- add a test case for BlobFileReader

Issue Number: https://github.com/tikv/tikv/issues/8635