### PR TITLE
Cherry-pick fix Segment fault when creates TitanCompactionFilter to tikv-4.x branch

### DIFF
--- a/src/compaction_filter.h
+++ b/src/compaction_filter.h
@@ -157,6 +157,11 @@ class TitanCompactionFilterFactory final : public CompactionFilterFactory {
           original_filter_factory_->CreateCompactionFilter(context);
       original_filter = original_filter_from_factory.get();
     }
+
+    if (original_filter == nullptr) {
+      return nullptr;
+    }
+
     return std::unique_ptr<CompactionFilter>(new TitanCompactionFilter(
         titan_db_impl_, cf_name_, original_filter,
         std::move(original_filter_from_factory), blob_storage, skip_value_));


### PR DESCRIPTION
Cherry-picking the following patch to tikv-4.x branch

```
Looks like it's not a undefined behavior to get a nullptr from compaction filter factory

Fixes #180 

Signed-off-by: DorianZheng <xingzhengde72@gmail.com>
```