### PR TITLE
Add checkpoint support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ if (WITH_TITAN_TESTS AND (NOT CMAKE_BUILD_TYPE STREQUAL "Release"))
         table_builder_test
         thread_safety_test
         titan_db_test
+        titan_checkpoint_test
         titan_options_test
         util_test
         compaction_filter_test

--- a/include/titan/checkpoint.h
+++ b/include/titan/checkpoint.h
@@ -5,16 +5,15 @@
 namespace rocksdb {
 namespace titandb {
 
-
 class Checkpoint {
  public:
   // Creates a Checkpoint object to be used for creating openable snapshots
   static Status Create(TitanDB* db, Checkpoint** checkpoint_ptr);
-  
+
   // Builds an openable snapshot of TitanDB. checkpoint_dir should contain an
   // absolute path. The specified directory should not exist, since it will be
   // created by the API.
-  // When a checkpoint is created: 
+  // When a checkpoint is created:
   // (1) SST and blob files are hard linked if the output directory is on the
   // same filesystem as the database, and copied otherwise.
   // (2) other required files (like MANIFEST) are always copied.

--- a/include/titan/checkpoint.h
+++ b/include/titan/checkpoint.h
@@ -12,26 +12,25 @@ class Checkpoint {
 
   // Builds an openable snapshot of TitanDB.
   // base_checkpoint_dir: checkpoint directory of base DB
-  // titan_checkpoint_dir: checkpoint directory of TitanDB, if not specified, 
+  // titan_checkpoint_dir: checkpoint directory of TitanDB, if not specified,
   // default value is {base_checkpoint_dir}/titandb.
-  // The specified directory should contain absolute path and not exist, it 
+  // The specified directory should contain absolute path and not exist, it
   // will be created by the API.
   // When a checkpoint is created:
   // (1) SST and blob files are hard linked if the output directory is on the
   //     same filesystem as the database, and copied otherwise.
   // (2) MANIFEST file specific to TitanDB will be regenerated based on all
   //     existing blob files.
-  // (3) other required files are always copied.  
+  // (3) other required files are always copied.
   // log_size_for_flush: if the total log file size is equal or larger than
   // this value, then a flush is triggered for all the column families. The
   // default value is 0, which means flush is always triggered. If you move
   // away from the default, the checkpoint may not contain up-to-date data
   // if WAL writing is not always enabled.
   // Flush will always trigger if it is 2PC.
-  virtual Status CreateCheckpoint(
-              const std::string& base_checkpoint_dir,
-              const std::string& titan_checkpoint_dir = "",
-              uint64_t log_size_for_flush = 0);
+  virtual Status CreateCheckpoint(const std::string& base_checkpoint_dir,
+                                  const std::string& titan_checkpoint_dir = "",
+                                  uint64_t log_size_for_flush = 0);
 
   virtual ~Checkpoint() {}
 };

--- a/include/titan/checkpoint.h
+++ b/include/titan/checkpoint.h
@@ -10,21 +10,28 @@ class Checkpoint {
   // Creates a Checkpoint object to be used for creating openable snapshots
   static Status Create(TitanDB* db, Checkpoint** checkpoint_ptr);
 
-  // Builds an openable snapshot of TitanDB. checkpoint_dir should contain an
-  // absolute path. The specified directory should not exist, since it will be
-  // created by the API.
+  // Builds an openable snapshot of TitanDB.
+  // base_checkpoint_dir: checkpoint directory of base DB
+  // titan_checkpoint_dir: checkpoint directory of TitanDB, if not specified, 
+  // default value is {base_checkpoint_dir}/titandb.
+  // The specified directory should contain absolute path and not exist, it 
+  // will be created by the API.
   // When a checkpoint is created:
   // (1) SST and blob files are hard linked if the output directory is on the
-  // same filesystem as the database, and copied otherwise.
-  // (2) other required files (like MANIFEST) are always copied.
+  //     same filesystem as the database, and copied otherwise.
+  // (2) MANIFEST file specific to TitanDB will be regenerated based on all
+  //     existing blob files.
+  // (3) other required files are always copied.  
   // log_size_for_flush: if the total log file size is equal or larger than
   // this value, then a flush is triggered for all the column families. The
   // default value is 0, which means flush is always triggered. If you move
   // away from the default, the checkpoint may not contain up-to-date data
   // if WAL writing is not always enabled.
   // Flush will always trigger if it is 2PC.
-  virtual Status CreateCheckpoint(const std::string& checkpoint_dir,
-                                  uint64_t log_size_for_flush = 0);
+  virtual Status CreateCheckpoint(
+              const std::string& base_checkpoint_dir,
+              const std::string& titan_checkpoint_dir = "",
+              uint64_t log_size_for_flush = 0);
 
   virtual ~Checkpoint() {}
 };

--- a/include/titan/checkpoint.h
+++ b/include/titan/checkpoint.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "db.h"
+
+namespace rocksdb {
+namespace titandb {
+
+
+class Checkpoint {
+ public:
+  // Creates a Checkpoint object to be used for creating openable snapshots
+  static Status Create(TitanDB* db, Checkpoint** checkpoint_ptr);
+  
+  // Builds an openable snapshot of TitanDB. checkpoint_dir should contain an
+  // absolute path. The specified directory should not exist, since it will be
+  // created by the API.
+  // When a checkpoint is created: 
+  // (1) SST and blob files are hard linked if the output directory is on the
+  // same filesystem as the database, and copied otherwise.
+  // (2) other required files (like MANIFEST) are always copied.
+  // log_size_for_flush: if the total log file size is equal or larger than
+  // this value, then a flush is triggered for all the column families. The
+  // default value is 0, which means flush is always triggered. If you move
+  // away from the default, the checkpoint may not contain up-to-date data
+  // if WAL writing is not always enabled.
+  // Flush will always trigger if it is 2PC.
+  virtual Status CreateCheckpoint(const std::string& checkpoint_dir,
+                                  uint64_t log_size_for_flush = 0);
+
+  virtual ~Checkpoint() {}
+};
+
+}  // namespace titandb
+}  // namespace rocksdb

--- a/include/titan/db.h
+++ b/include/titan/db.h
@@ -6,6 +6,8 @@
 namespace rocksdb {
 namespace titandb {
 
+class VersionEdit;
+
 struct TitanCFDescriptor {
   std::string name;
   TitanCFOptions options;
@@ -118,16 +120,12 @@ class TitanDB : public StackableDB {
     return Status::NotSupported("TitanDB doesn't support this operation");
   }
 
-  // Get TitanDB live files base on rocksdb::DB::GetLiveFiles 
-  // 
-  // base_ret and base_manifest_file_size are derived from rocksdb::DB::GetLiveFiles
-  // titan_ret is the list of all files in dirname_ directory(including obsolete files)
-  // titan_manifest_file_size is the size of manifest file in dirname_ directory
-  virtual Status GetTitanLiveFiles(std::vector<std::string>& base_ret,
-                              uint64_t* base_manifest_file_size,
-                              std::vector<std::string>& titan_ret,
-                              uint64_t* titan_manifest_file_size,
-                              bool flush_memtable = true) = 0;
+  // Get all files in /titandb directory after disable file deletions
+  // edits include all blob file records of every column family
+  virtual Status GetAllTitanFiles(std::vector<std::string>& /*files*/,
+                                  std::vector<VersionEdit>* /*edits*/) {
+    return Status::NotSupported("TitanDB doesn't support this operation");
+  }
                               
   using rocksdb::StackableDB::SingleDelete;
   Status SingleDelete(const WriteOptions& /*wopts*/,

--- a/include/titan/db.h
+++ b/include/titan/db.h
@@ -118,9 +118,10 @@ class TitanDB : public StackableDB {
     return Status::NotSupported("TitanDB doesn't support this operation");
   }
 
-  // Get TitanDB live files base on rocksdb::DB::GetLiveFiles
+  // Get TitanDB live files base on rocksdb::DB::GetLiveFiles 
+  // 
   // base_ret and base_manifest_file_size are derived from rocksdb::DB::GetLiveFiles
-  // titan_ret is the list of all files in dirname_ directory
+  // titan_ret is the list of all files in dirname_ directory(including obsolete files)
   // titan_manifest_file_size is the size of manifest file in dirname_ directory
   virtual Status GetTitanLiveFiles(std::vector<std::string>& base_ret,
                               uint64_t* base_manifest_file_size,

--- a/include/titan/db.h
+++ b/include/titan/db.h
@@ -126,7 +126,7 @@ class TitanDB : public StackableDB {
                                   std::vector<VersionEdit>* /*edits*/) {
     return Status::NotSupported("TitanDB doesn't support this operation");
   }
-                              
+
   using rocksdb::StackableDB::SingleDelete;
   Status SingleDelete(const WriteOptions& /*wopts*/,
                       ColumnFamilyHandle* /*column_family*/,

--- a/include/titan/db.h
+++ b/include/titan/db.h
@@ -108,6 +108,26 @@ class TitanDB : public StackableDB {
     return Status::NotSupported("TitanDB doesn't support this operation");
   }
 
+  using StackableDB::DisableFileDeletions;
+  Status DisableFileDeletions() override {
+    return Status::NotSupported("TitanDB doesn't support this operation");
+  }
+
+  using StackableDB::EnableFileDeletions;
+  Status EnableFileDeletions(bool /*force*/) override {
+    return Status::NotSupported("TitanDB doesn't support this operation");
+  }
+
+  // Get TitanDB live files base on rocksdb::DB::GetLiveFiles
+  // base_ret and base_manifest_file_size are derived from rocksdb::DB::GetLiveFiles
+  // titan_ret is the list of all files in dirname_ directory
+  // titan_manifest_file_size is the size of manifest file in dirname_ directory
+  virtual Status GetTitanLiveFiles(std::vector<std::string>& base_ret,
+                              uint64_t* base_manifest_file_size,
+                              std::vector<std::string>& titan_ret,
+                              uint64_t* titan_manifest_file_size,
+                              bool flush_memtable = true) = 0;
+                              
   using rocksdb::StackableDB::SingleDelete;
   Status SingleDelete(const WriteOptions& /*wopts*/,
                       ColumnFamilyHandle* /*column_family*/,

--- a/src/blob_file_set.cc
+++ b/src/blob_file_set.cc
@@ -365,8 +365,8 @@ void BlobFileSet::GetAllFiles(std::vector<std::string>* files,
   }
 
   // Append current MANIFEST and CURRENT file name
-  files->emplace_back(DescriptorFileName("/titandb", manifest_file_number_));
-  files->emplace_back(CurrentFileName("/titandb"));
+  files->emplace_back(DescriptorFileName("", manifest_file_number_));
+  files->emplace_back(CurrentFileName(""));
 }
 
 }  // namespace titandb

--- a/src/blob_file_set.cc
+++ b/src/blob_file_set.cc
@@ -329,7 +329,7 @@ void BlobFileSet::GetObsoleteFiles(std::vector<std::string>* obsolete_files,
   obsolete_manifests_.clear();
 }
 
-void BlobFileSet::GetAllFiles(std::vector<std::string>* files, 
+void BlobFileSet::GetAllFiles(std::vector<std::string>* files,
                               std::vector<VersionEdit>* edits) {
   std::vector<std::string> all_blob_files;
 

--- a/src/blob_file_set.h
+++ b/src/blob_file_set.h
@@ -83,7 +83,7 @@ class BlobFileSet {
                         SequenceNumber oldest_sequence);
 
   // REQUIRES: mutex is held
-  void GetAllFiles(std::vector<std::string>* files, 
+  void GetAllFiles(std::vector<std::string>* files,
                    std::vector<VersionEdit>* edits);
 
   // REQUIRES: mutex is held

--- a/src/blob_file_set.h
+++ b/src/blob_file_set.h
@@ -83,7 +83,8 @@ class BlobFileSet {
                         SequenceNumber oldest_sequence);
 
   // REQUIRES: mutex is held
-  void GetAllFiles(std::vector<std::string>* files, uint64_t* manifest_file_size);
+  void GetAllFiles(std::vector<std::string>* files, 
+                   std::vector<VersionEdit>* edits);
 
   // REQUIRES: mutex is held
   bool IsColumnFamilyObsolete(uint32_t cf_id) {

--- a/src/blob_file_set.h
+++ b/src/blob_file_set.h
@@ -83,7 +83,7 @@ class BlobFileSet {
                         SequenceNumber oldest_sequence);
 
   // REQUIRES: mutex is held
-  void GetLiveFiles(std::vector<std::string>* live_files, uint64_t* manifest_file_size);
+  void GetAllFiles(std::vector<std::string>* files, uint64_t* manifest_file_size);
 
   // REQUIRES: mutex is held
   bool IsColumnFamilyObsolete(uint32_t cf_id) {
@@ -121,6 +121,7 @@ class BlobFileSet {
   std::unordered_map<uint32_t, std::shared_ptr<BlobStorage>> column_families_;
   std::unique_ptr<log::Writer> manifest_;
   std::atomic<uint64_t> next_file_number_{1};
+  uint64_t manifest_file_number_;
 };
 
 }  // namespace titandb

--- a/src/blob_file_set.h
+++ b/src/blob_file_set.h
@@ -83,6 +83,9 @@ class BlobFileSet {
                         SequenceNumber oldest_sequence);
 
   // REQUIRES: mutex is held
+  void GetLiveFiles(std::vector<std::string>* live_files, uint64_t* manifest_file_size);
+
+  // REQUIRES: mutex is held
   bool IsColumnFamilyObsolete(uint32_t cf_id) {
     return obsolete_columns_.count(cf_id) > 0;
   }

--- a/src/blob_storage.cc
+++ b/src/blob_storage.cc
@@ -192,8 +192,8 @@ void BlobStorage::GetAllFiles(std::vector<std::string>* files) {
 
   for (auto& file : files_) {
     uint64_t file_number = file.first;
-    // relative to dbname, the form like: "/titandb/[0-9].blob"
-    files->emplace_back(BlobFileName("", "titandb", file_number));
+    // relative to dirname
+    files->emplace_back(BlobFileName("", file_number));
   }
 }
 

--- a/src/blob_storage.cc
+++ b/src/blob_storage.cc
@@ -187,11 +187,10 @@ void BlobStorage::GetObsoleteFiles(std::vector<std::string>* obsolete_files,
   }
 }
 
-
 void BlobStorage::GetAllFiles(std::vector<std::string>* files) {
   MutexLock l(&mutex_);
 
-  for (auto &file : files_) {
+  for (auto& file : files_) {
     uint64_t file_number = file.first;
     // relative to dbname, the form like: "/titandb/[0-9].blob"
     files->emplace_back(BlobFileName("", "titandb", file_number));

--- a/src/blob_storage.cc
+++ b/src/blob_storage.cc
@@ -187,6 +187,19 @@ void BlobStorage::GetObsoleteFiles(std::vector<std::string>* obsolete_files,
   }
 }
 
+
+void BlobStorage::GetLiveFiles(std::vector<std::string>* live_files) {
+  MutexLock l(&mutex_);
+
+  for (auto &file : files_) {
+    if (!file.second->is_obsolete()) {
+      uint64_t file_number = file.first;
+      // relative to dbname, the form like: "/titandb/[0-9].blob"
+      live_files->emplace_back(BlobFileName("", "titandb", file_number));
+    }
+  }
+}
+
 void BlobStorage::ComputeGCScore() {
   // TODO: no need to recompute all everytime
   MutexLock l(&mutex_);

--- a/src/blob_storage.cc
+++ b/src/blob_storage.cc
@@ -188,15 +188,13 @@ void BlobStorage::GetObsoleteFiles(std::vector<std::string>* obsolete_files,
 }
 
 
-void BlobStorage::GetLiveFiles(std::vector<std::string>* live_files) {
+void BlobStorage::GetAllFiles(std::vector<std::string>* files) {
   MutexLock l(&mutex_);
 
   for (auto &file : files_) {
-    if (!file.second->is_obsolete()) {
-      uint64_t file_number = file.first;
-      // relative to dbname, the form like: "/titandb/[0-9].blob"
-      live_files->emplace_back(BlobFileName("", "titandb", file_number));
-    }
+    uint64_t file_number = file.first;
+    // relative to dbname, the form like: "/titandb/[0-9].blob"
+    files->emplace_back(BlobFileName("", "titandb", file_number));
   }
 }
 

--- a/src/blob_storage.h
+++ b/src/blob_storage.h
@@ -104,6 +104,9 @@ class BlobStorage {
   void GetObsoleteFiles(std::vector<std::string>* obsolete_files,
                         SequenceNumber oldest_sequence);
 
+  // Gets all live blob files (start with '/titandb' prefix)
+  void GetLiveFiles(std::vector<std::string>* live_files);
+
   // Mark the file as obsolete, and retrun value indicates whether the file is
   // founded.
   bool MarkFileObsolete(uint64_t file_number, SequenceNumber obsolete_sequence);

--- a/src/blob_storage.h
+++ b/src/blob_storage.h
@@ -104,8 +104,8 @@ class BlobStorage {
   void GetObsoleteFiles(std::vector<std::string>* obsolete_files,
                         SequenceNumber oldest_sequence);
 
-  // Gets all live blob files (start with '/titandb' prefix)
-  void GetLiveFiles(std::vector<std::string>* live_files);
+  // Gets all files (start with '/titandb' prefix), including obsolete files.
+  void GetAllFiles(std::vector<std::string>* files);
 
   // Mark the file as obsolete, and retrun value indicates whether the file is
   // founded.

--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -813,8 +813,10 @@ Status TitanDBImpl::GetAllTitanFiles(std::vector<std::string>& files,
     return s;
   }
 
-  MutexLock l(&mutex_);
-  blob_file_set_->GetAllFiles(&files, edits);
+  {
+    MutexLock l(&mutex_);
+    blob_file_set_->GetAllFiles(&files, edits);
+  }
 
   return EnableFileDeletions(false);
 }

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -116,11 +116,10 @@ class TitanDBImpl : public TitanDB {
   using TitanDB::EnableFileDeletions;
   Status EnableFileDeletions(bool force) override;
 
-  Status GetTitanLiveFiles(std::vector<std::string>& base_ret,
-                              uint64_t* base_manifest_file_size,
-                              std::vector<std::string>& titan_ret,
-                              uint64_t* titan_manifest_file_size,
-                              bool flush_memtable = true) override;
+  using TitanDB::GetAllTitanFiles;
+  Status GetAllTitanFiles(std::vector<std::string>& files,
+                          std::vector<VersionEdit>* edits) override;
+
   Status DeleteFilesInRanges(ColumnFamilyHandle* column_family,
                              const RangePtr* ranges, size_t n,
                              bool include_end = true) override;

--- a/src/db_impl_files.cc
+++ b/src/db_impl_files.cc
@@ -5,7 +5,7 @@ namespace titandb {
 
 Status TitanDBImpl::PurgeObsoleteFilesImpl() {
   Status s;
-  
+
   MutexLock delete_file_lock(&delete_titandb_file_mutex_);
   if (disable_titandb_file_deletions_ > 0) {
     return s;

--- a/src/db_impl_files.cc
+++ b/src/db_impl_files.cc
@@ -5,6 +5,12 @@ namespace titandb {
 
 Status TitanDBImpl::PurgeObsoleteFilesImpl() {
   Status s;
+  
+  MutexLock delete_file_lock(&delete_titandb_file_mutex_);
+  if (disable_titandb_file_deletions_ > 0) {
+    return s;
+  }
+
   std::vector<std::string> candidate_files;
   auto oldest_sequence = GetOldestSnapshotSequence();
   {

--- a/src/titan_checkpoint_impl.cc
+++ b/src/titan_checkpoint_impl.cc
@@ -90,9 +90,9 @@ Status TitanCheckpointImpl::CreateCheckpoint(
     const std::string& titan_checkpoint_dir, uint64_t log_size_for_flush) {
   TitanDBOptions titandb_options = db_->GetTitanDBOptions();
   std::string full_private_path;
-  std::string checkpoint_dir = base_checkpoint_dir + "/titandb";
-  if (!titan_checkpoint_dir.empty()) {
-    checkpoint_dir = titan_checkpoint_dir;
+  std::string checkpoint_dir = titan_checkpoint_dir;
+  if (checkpoint_dir.empty()) {
+    checkpoint_dir = base_checkpoint_dir + "/titandb";
   }
   // Check TitanDB checkpoint directory
   Status s = db_->GetEnv()->FileExists(checkpoint_dir);

--- a/src/titan_checkpoint_impl.cc
+++ b/src/titan_checkpoint_impl.cc
@@ -1,6 +1,6 @@
 #include "titan_checkpoint_impl.h"
 
-#include <iostream>
+
 #include <cinttypes>
 #include "file/file_util.h"
 #include "file/filename.h"
@@ -176,7 +176,7 @@ Status TitanCheckpointImpl::CreateCustomCheckpoint(
   bool same_fs = true;
   VectorLogPtr live_wal_files;
 
-  bool flush_memtable = false;
+  bool flush_memtable = true;
   if (s.ok()) {
     if (!db_options.allow_2pc) {
       if (log_size_for_flush == port::kMaxUint64) {
@@ -316,15 +316,7 @@ Status TitanCheckpointImpl::CreateCustomCheckpoint(
         s = copy_file_cb(db_->GetName(), src_fname, 0, type);        
       }
     }
-    if ((type != kTableFile && type != kBlobFile) || (!same_fs)) {
-      if (type == kDescriptorFile) {
-        s = copy_file_cb(db_->GetName(), src_fname,
-                (in_titan_dir) ? titan_manifest_file_size : base_manifest_file_size,
-                type);  
-      } else {
-        s = copy_file_cb(db_->GetName(), src_fname, 0, type);        
-      }
-    }
+    
   }
   // Write manifest name to CURRENT file
   if (s.ok() && !base_current_fname.empty() && !base_manifest_fname.empty()) {

--- a/src/titan_checkpoint_impl.cc
+++ b/src/titan_checkpoint_impl.cc
@@ -1,0 +1,374 @@
+#include "titan_checkpoint_impl.h"
+
+#include <iostream>
+#include <cinttypes>
+#include "file/file_util.h"
+#include "file/filename.h"
+#include "port/port.h"
+#include "rocksdb/transaction_log.h"
+#include "test_util/sync_point.h"
+
+namespace rocksdb {
+namespace titandb {
+
+Status Checkpoint::Create(TitanDB* db, Checkpoint** checkpoint_ptr) {
+  *checkpoint_ptr = new TitanCheckpointImpl(db);
+  return Status::OK();
+}
+
+Status Checkpoint::CreateCheckpoint(const std::string& /*checkpoint_dir*/,
+                                    uint64_t /*log_size_for_flush*/) {
+  return Status::NotSupported("TitanDB doesn't support this operation");
+}
+
+void TitanCheckpointImpl::CleanStagingDirectory(
+    const std::string& full_private_path, Logger* info_log) {
+    std::vector<std::string> subchildren;
+  Status s = db_->GetEnv()->FileExists(full_private_path);
+  if (s.IsNotFound()) {
+    return;
+  }
+  ROCKS_LOG_INFO(info_log, "File exists %s -- %s",
+                 full_private_path.c_str(), s.ToString().c_str());
+  s = db_->GetEnv()->GetChildren(full_private_path, &subchildren);
+  if (s.ok()) {
+    for (auto& subchild : subchildren) {
+      std::string subchild_path = full_private_path + "/" + subchild;
+      if (subchild == "titandb") {
+        CleanStagingDirectory(subchild_path, info_log);
+        ROCKS_LOG_INFO(info_log, "Clean titandb directory %s", subchild_path.c_str());
+      } else {
+        s = db_->GetEnv()->DeleteFile(subchild_path);
+        ROCKS_LOG_INFO(info_log, "Delete file %s -- %s", subchild_path.c_str(),
+                       s.ToString().c_str());
+      }
+
+    }
+  }
+  // finally delete the private dir
+  s = db_->GetEnv()->DeleteDir(full_private_path);
+  ROCKS_LOG_INFO(info_log, "Delete dir %s -- %s",
+                 full_private_path.c_str(), s.ToString().c_str());
+}
+
+
+// Builds an openable checkpoint of TitanDB
+Status TitanCheckpointImpl::CreateCheckpoint(const std::string& checkpoint_dir,
+                                        uint64_t log_size_for_flush) {
+  DBOptions db_options = db_->GetDBOptions();
+  Status s = db_->GetEnv()->FileExists(checkpoint_dir);
+  if (s.ok()) {
+    return Status::InvalidArgument("Directory exists");
+  } else if (!s.IsNotFound()) {
+    assert(s.IsIOError());
+    return s;
+  }
+
+  ROCKS_LOG_INFO(
+          db_options.info_log,
+          "Started the checkpoint process -- creating checkpoint in directory %s",
+          checkpoint_dir.c_str());
+
+  size_t final_nonslash_idx = checkpoint_dir.find_last_not_of('/');
+  if (final_nonslash_idx == std::string::npos) {
+    // npos means it's only slashes or empty. Non-empty means it's the root
+    // directory, but it shouldn't be because we verified above the directory
+    // doesn't exist.
+    assert(checkpoint_dir.empty());
+    return Status::InvalidArgument("Invalid checkpoint directory name");
+  }
+
+  std::string full_private_path =
+          checkpoint_dir.substr(0, final_nonslash_idx + 1) + ".tmp";
+  ROCKS_LOG_INFO(
+          db_options.info_log,
+          "Checkpoint process -- using temporary directory %s",
+          full_private_path.c_str());
+  CleanStagingDirectory(full_private_path, db_options.info_log.get());
+  // create checkpoint directory and subdirectory
+  s = db_->GetEnv()->CreateDir(full_private_path);
+  if (s.ok()) {
+    s = db_->GetEnv()->CreateDir(full_private_path + "/titandb");
+  }
+  uint64_t sequence_number = 0;
+  if (s.ok()) {
+    // disable file deletions
+    s = db_->DisableFileDeletions();
+    const bool disabled_file_deletions = s.ok();
+    if (s.ok()) {
+      s = CreateCustomCheckpoint(
+              db_options,
+              [&](const std::string& src_dirname, const std::string& fname,
+                  FileType) {
+                ROCKS_LOG_INFO(db_options.info_log, "Hard Linking %s", fname.c_str());
+                return db_->GetEnv()->LinkFile(src_dirname + fname,
+                                               full_private_path + fname);
+              } /* link_file_cb */,
+              [&](const std::string& src_dirname, const std::string& fname,
+                  uint64_t size_limit_bytes, FileType) {
+                ROCKS_LOG_INFO(db_options.info_log, "Copying %s", fname.c_str());
+                return CopyFile(db_->GetEnv(), src_dirname + fname,
+                                full_private_path + fname, size_limit_bytes,
+                                db_options.use_fsync);
+              } /* copy_file_cb */,
+              [&](const std::string& fname, const std::string& contents, FileType) {
+                ROCKS_LOG_INFO(db_options.info_log, "Creating %s", fname.c_str());
+                return CreateFile(db_->GetEnv(), full_private_path + fname, contents,
+                                  db_options.use_fsync);
+              } /* create_file_cb */,
+              &sequence_number, log_size_for_flush);
+    }
+
+    if (disabled_file_deletions) {
+      // we copied all the files, enable file deletions
+      Status ss = db_->EnableFileDeletions(false);
+      assert(ss.ok());
+    }
+
+  }
+
+  if (s.ok()) {
+    // move tmp private backup to real checkpoint directory
+    s = db_->GetEnv()->RenameFile(full_private_path, checkpoint_dir);
+  }
+  if (s.ok()) {
+    std::unique_ptr<Directory> checkpoint_directory;
+    db_->GetEnv()->NewDirectory(checkpoint_dir, &checkpoint_directory);
+    if (checkpoint_directory != nullptr) {
+      s = checkpoint_directory->Fsync();
+    }
+  }
+
+  if (s.ok()) {
+    // here we know that we succeeded and installed the new checkpoint
+    ROCKS_LOG_INFO(db_options.info_log, "Checkpoint DONE. All is good");
+    ROCKS_LOG_INFO(db_options.info_log, "Checkpoint sequence number: %" PRIu64,
+                   sequence_number);
+  } else {
+    // clean all the files we might have created
+    ROCKS_LOG_INFO(db_options.info_log, "Checkpoint failed -- %s",
+                   s.ToString().c_str());
+    CleanStagingDirectory(full_private_path, db_options.info_log.get());
+  }
+  return s;
+}
+
+Status TitanCheckpointImpl::CreateCustomCheckpoint(
+        const DBOptions& db_options,
+        std::function<Status(const std::string& src_dirname,
+                             const std::string& src_fname, FileType type)>
+        link_file_cb,
+        std::function<Status(const std::string& src_dirname,
+                             const std::string& src_fname,
+                             uint64_t size_limit_bytes, FileType type)>
+        copy_file_cb,
+        std::function<Status(const std::string& fname, const std::string& contents,
+                             FileType type)>
+        create_file_cb,
+        uint64_t* sequence_number, uint64_t log_size_for_flush) {
+  Status s;
+  std::vector<std::string> live_files;
+  std::vector<std::string> titan_live_files;
+  uint64_t base_manifest_file_size = 0;
+  uint64_t titan_manifest_file_size = 0;
+  uint64_t min_log_num = port::kMaxUint64;
+  *sequence_number = db_->GetLatestSequenceNumber();
+  bool same_fs = true;
+  VectorLogPtr live_wal_files;
+
+  bool flush_memtable = false;
+  if (s.ok()) {
+    if (!db_options.allow_2pc) {
+      if (log_size_for_flush == port::kMaxUint64) {
+        flush_memtable = false;
+      } else if (log_size_for_flush > 0) {
+        // if out standing log files are small, we skip the flush.
+        s = db_->GetSortedWalFiles(live_wal_files);
+
+        if (!s.ok()) {
+          return s;
+        }
+
+        // Don't flush column families if total log size is smaller than
+        // log_size_for_flush. We copy the log files instead.
+        // We may be able to cover 2PC case too.
+        uint64_t total_wal_size = 0;
+        for (auto& wal : live_wal_files) {
+          total_wal_size += wal->SizeFileBytes();
+        }
+        if (total_wal_size < log_size_for_flush) {
+          flush_memtable = false;
+        }
+        live_wal_files.clear();
+      }
+    }
+
+    // this will return live files prefixed with "/"
+    s = db_->GetTitanLiveFiles(live_files, &base_manifest_file_size,
+                               titan_live_files, &titan_manifest_file_size,
+                               flush_memtable);
+    
+    if (s.ok() && db_options.allow_2pc) {
+      // If 2PC is enabled, we need to get minimum log number after the flush.
+      // Need to refetch the live files to recapture the checkpoint.
+      if (!db_->GetIntProperty(DB::Properties::kMinLogNumberToKeep,
+                               &min_log_num)) {
+        return Status::InvalidArgument(
+                "2PC enabled but cannot fine the min log number to keep.");
+      }
+      // GetTitanLiveFiles() calls the rocksdb::DB::GetLiveFiles() internally.
+      // We need to refetch live files with flush to handle this case:
+      // A previous 000001.log contains the prepare record of transaction tnx1.
+      // The current log file is 000002.log, and sequence_number points to this
+      // file.
+      // After calling rocksdb::DB::GetLiveFiles(), 000003.log is created.
+      // Then tnx1 is committed. The commit record is written to 000003.log.
+      // Now we fetch min_log_num, which will be 3.
+      // Then only 000002.log and 000003.log will be copied, and 000001.log will
+      // be skipped. 000003.log contains commit message of tnx1, but we don't
+      // have respective prepare record for it.
+      // In order to avoid this situation, we need to force flush to make sure
+      // all transactions committed before getting min_log_num will be flushed
+      // to SST files.
+      // We cannot get min_log_num before calling the rocksdb::DB::GetLiveFiles()
+      // for the first time, because if we do that, all the logs files will be
+      // included, far more than needed.
+      s = db_->GetTitanLiveFiles(live_files, &base_manifest_file_size,
+                                 titan_live_files, &titan_manifest_file_size,
+                                 flush_memtable);
+    }
+
+    TEST_SYNC_POINT("TitanCheckpointImpl::CreateCheckpoint:SavedLiveFiles1");
+    TEST_SYNC_POINT("TitanCheckpointImpl::CreateCheckpoint:SavedLiveFiles2");
+    db_->FlushWAL(false /* sync */);
+  }
+  // if we have more than one column family, we need to also get WAL files
+  if (s.ok()) {
+    s = db_->GetSortedWalFiles(live_wal_files);
+  }
+  if (!s.ok()) {
+    return s;
+  }
+
+  size_t wal_size = live_wal_files.size();
+
+  live_files.insert(live_files.end(), titan_live_files.begin(), titan_live_files.end());
+
+  // copy/hard link live_files
+  std::string base_manifest_fname, base_current_fname;
+  std::string titan_manifest_fname, titan_current_fname;
+  for (size_t i = 0; s.ok() && i < live_files.size(); ++i) {
+    uint64_t number;
+    FileType type;
+    bool ok, in_titan_dir = false;
+    // the filename prefix is '/titandb'
+    if (live_files[i].rfind("/titandb", 0) == 0) {
+      in_titan_dir = true;
+      ok = ParseFileName(live_files[i].substr(8), &number, &type);
+    } else {
+      ok = ParseFileName(live_files[i], &number, &type);
+    }
+
+    if (!ok) {
+      s = Status::Corruption("Can't parse file name. This is very bad");
+      break;
+    }
+    // we should only get sst, blob, options, manifest and current files here
+    assert(type == kTableFile || type == kBlobFile || type == kDescriptorFile ||
+           type == kCurrentFile || type == kOptionsFile);
+    assert(live_files[i].size() > 0 && live_files[i][0] == '/');
+    if (type == kCurrentFile) {
+      // We will craft the current file manually to ensure it's consistent with
+      // the manifest number. This is necessary because current's file contents
+      // can change during checkpoint creation.
+      if (in_titan_dir) {
+        titan_current_fname = live_files[i];
+      } else {
+        base_current_fname = live_files[i];
+      }
+      continue;
+    } else if (type == kDescriptorFile) {
+      if (in_titan_dir) {
+        titan_manifest_fname = live_files[i];
+      } else {
+        base_manifest_fname = live_files[i];
+      }
+    }
+    std::string src_fname = live_files[i];
+
+    // rules:
+    // * if it's kTableFile/kBlobFile, then it's shared
+    // * if it's kDescriptorFile, limit the size to manifest_file_size
+    // * always copy if cross-device link
+    if ((type == kTableFile || type == kBlobFile) && same_fs) {
+      s = link_file_cb(db_->GetName(), src_fname, type);
+      if (s.IsNotSupported()) {
+        same_fs = false;
+        s = Status::OK();
+      }
+    }
+    if ((type != kTableFile && type != kBlobFile) || (!same_fs)) {
+      if (type == kDescriptorFile) {
+        s = copy_file_cb(db_->GetName(), src_fname,
+                (in_titan_dir) ? titan_manifest_file_size : base_manifest_file_size,
+                type);  
+      } else {
+        s = copy_file_cb(db_->GetName(), src_fname, 0, type);        
+      }
+    }
+    if ((type != kTableFile && type != kBlobFile) || (!same_fs)) {
+      if (type == kDescriptorFile) {
+        s = copy_file_cb(db_->GetName(), src_fname,
+                (in_titan_dir) ? titan_manifest_file_size : base_manifest_file_size,
+                type);  
+      } else {
+        s = copy_file_cb(db_->GetName(), src_fname, 0, type);        
+      }
+    }
+  }
+  // Write manifest name to CURRENT file
+  if (s.ok() && !base_current_fname.empty() && !base_manifest_fname.empty()) {
+    create_file_cb(base_current_fname, base_manifest_fname.substr(1) + "\n",
+                   kCurrentFile);
+  }
+  if (s.ok() && !titan_current_fname.empty() && !titan_manifest_fname.empty()) {
+    create_file_cb(titan_current_fname, titan_manifest_fname.substr(8) + "\n",
+                   kCurrentFile);
+  }
+
+  ROCKS_LOG_INFO(db_options.info_log, "Number of log files %" ROCKSDB_PRIszt,
+                 live_wal_files.size());
+
+  // Link WAL files. Copy exact size of last one because it is the only one
+  // that has changes after the last flush.
+  for (size_t i = 0; s.ok() && i < wal_size; ++i) {
+    if ((live_wal_files[i]->Type() == kAliveLogFile) &&
+        (!flush_memtable ||
+         live_wal_files[i]->StartSequence() >= *sequence_number ||
+         live_wal_files[i]->LogNumber() >= min_log_num)) {
+      if (i + 1 == wal_size) {
+        s = copy_file_cb(db_options.wal_dir, live_wal_files[i]->PathName(),
+                         live_wal_files[i]->SizeFileBytes(), kLogFile);
+        break;
+      }
+      if (same_fs) {
+        // we only care about live log files
+        s = link_file_cb(db_options.wal_dir, live_wal_files[i]->PathName(),
+                         kLogFile);
+        if (s.IsNotSupported()) {
+          same_fs = false;
+          s = Status::OK();
+        }
+      }
+      if (!same_fs) {
+        s = copy_file_cb(db_options.wal_dir, live_wal_files[i]->PathName(), 0,
+                         kLogFile);
+      }
+    }
+  }
+
+  return s;
+}
+
+}  // namespace titandb
+}  // namespace rocksdb

--- a/src/titan_checkpoint_impl.cc
+++ b/src/titan_checkpoint_impl.cc
@@ -1,12 +1,15 @@
 #include "titan_checkpoint_impl.h"
 
-
 #include <cinttypes>
+
 #include "file/file_util.h"
 #include "file/filename.h"
 #include "port/port.h"
 #include "rocksdb/transaction_log.h"
 #include "test_util/sync_point.h"
+#include "util.h"
+#include "utilities/checkpoint/checkpoint_impl.h"
+#include "version_edit.h"
 
 namespace rocksdb {
 namespace titandb {
@@ -23,38 +26,64 @@ Status Checkpoint::CreateCheckpoint(const std::string& /*checkpoint_dir*/,
 
 void TitanCheckpointImpl::CleanStagingDirectory(
     const std::string& full_private_path, Logger* info_log) {
-    std::vector<std::string> subchildren;
+  std::vector<std::string> subchildren;
   Status s = db_->GetEnv()->FileExists(full_private_path);
   if (s.IsNotFound()) {
     return;
   }
-  ROCKS_LOG_INFO(info_log, "File exists %s -- %s",
-                 full_private_path.c_str(), s.ToString().c_str());
+  ROCKS_LOG_INFO(info_log, "File exists %s -- %s", full_private_path.c_str(),
+                 s.ToString().c_str());
   s = db_->GetEnv()->GetChildren(full_private_path, &subchildren);
   if (s.ok()) {
     for (auto& subchild : subchildren) {
       std::string subchild_path = full_private_path + "/" + subchild;
       if (subchild == "titandb") {
         CleanStagingDirectory(subchild_path, info_log);
-        ROCKS_LOG_INFO(info_log, "Clean titandb directory %s", subchild_path.c_str());
+        ROCKS_LOG_INFO(info_log, "Clean titandb directory %s",
+                       subchild_path.c_str());
       } else {
         s = db_->GetEnv()->DeleteFile(subchild_path);
         ROCKS_LOG_INFO(info_log, "Delete file %s -- %s", subchild_path.c_str(),
                        s.ToString().c_str());
       }
-
     }
   }
-  // finally delete the private dir
+  // Finally delete the private dir
   s = db_->GetEnv()->DeleteDir(full_private_path);
-  ROCKS_LOG_INFO(info_log, "Delete dir %s -- %s",
-                 full_private_path.c_str(), s.ToString().c_str());
+  ROCKS_LOG_INFO(info_log, "Delete dir %s -- %s", full_private_path.c_str(),
+                 s.ToString().c_str());
 }
 
+Status TitanCheckpointImpl::CreateTitanManifest(
+    const std::string& file_name, std::vector<VersionEdit>* edits) {
+  Status s;
+  Env* env = db_->GetEnv();
+  bool use_fsync = db_->GetDBOptions().use_fsync;
+  const EnvOptions env_options;
+  std::unique_ptr<WritableFileWriter> file;
+
+  {
+    std::unique_ptr<WritableFile> f;
+    s = env->NewWritableFile(file_name, &f, env_options);
+    if (!s.ok()) return s;
+    file.reset(new WritableFileWriter(std::move(f), file_name, env_options));
+  }
+  std::unique_ptr<log::Writer> manifest;
+  manifest.reset(new log::Writer(std::move(file), 0, false));
+
+  for (auto& edit : *edits) {
+    std::string record;
+    edit.EncodeTo(&record);
+    s = manifest->AddRecord(record);
+    if (!s.ok()) return s;
+  }
+
+  return manifest->file()->Sync(use_fsync);
+}
 
 // Builds an openable checkpoint of TitanDB
 Status TitanCheckpointImpl::CreateCheckpoint(const std::string& checkpoint_dir,
-                                        uint64_t log_size_for_flush) {
+                                             uint64_t log_size_for_flush) {
   DBOptions db_options = db_->GetDBOptions();
   Status s = db_->GetEnv()->FileExists(checkpoint_dir);
   if (s.ok()) {
@@ -65,9 +94,9 @@ Status TitanCheckpointImpl::CreateCheckpoint(const std::string& checkpoint_dir,
   }
 
   ROCKS_LOG_INFO(
-          db_options.info_log,
-          "Started the checkpoint process -- creating checkpoint in directory %s",
-          checkpoint_dir.c_str());
+      db_options.info_log,
+      "Started the checkpoint process -- creating checkpoint in directory %s",
+      checkpoint_dir.c_str());
 
   size_t final_nonslash_idx = checkpoint_dir.find_last_not_of('/');
   if (final_nonslash_idx == std::string::npos) {
@@ -79,56 +108,54 @@ Status TitanCheckpointImpl::CreateCheckpoint(const std::string& checkpoint_dir,
   }
 
   std::string full_private_path =
-          checkpoint_dir.substr(0, final_nonslash_idx + 1) + ".tmp";
-  ROCKS_LOG_INFO(
-          db_options.info_log,
-          "Checkpoint process -- using temporary directory %s",
-          full_private_path.c_str());
+      checkpoint_dir.substr(0, final_nonslash_idx + 1) + ".tmp";
+  ROCKS_LOG_INFO(db_options.info_log,
+                 "Checkpoint process -- using temporary directory %s",
+                 full_private_path.c_str());
   CleanStagingDirectory(full_private_path, db_options.info_log.get());
-  // create checkpoint directory and subdirectory
+  // Create checkpoint directory and subdirectory
   s = db_->GetEnv()->CreateDir(full_private_path);
   if (s.ok()) {
     s = db_->GetEnv()->CreateDir(full_private_path + "/titandb");
   }
   uint64_t sequence_number = 0;
   if (s.ok()) {
-    // disable file deletions
+    // Disable file deletions
     s = db_->DisableFileDeletions();
     const bool disabled_file_deletions = s.ok();
     if (s.ok()) {
       s = CreateCustomCheckpoint(
-              db_options,
-              [&](const std::string& src_dirname, const std::string& fname,
-                  FileType) {
-                ROCKS_LOG_INFO(db_options.info_log, "Hard Linking %s", fname.c_str());
-                return db_->GetEnv()->LinkFile(src_dirname + fname,
-                                               full_private_path + fname);
-              } /* link_file_cb */,
-              [&](const std::string& src_dirname, const std::string& fname,
-                  uint64_t size_limit_bytes, FileType) {
-                ROCKS_LOG_INFO(db_options.info_log, "Copying %s", fname.c_str());
-                return CopyFile(db_->GetEnv(), src_dirname + fname,
-                                full_private_path + fname, size_limit_bytes,
-                                db_options.use_fsync);
-              } /* copy_file_cb */,
-              [&](const std::string& fname, const std::string& contents, FileType) {
-                ROCKS_LOG_INFO(db_options.info_log, "Creating %s", fname.c_str());
-                return CreateFile(db_->GetEnv(), full_private_path + fname, contents,
-                                  db_options.use_fsync);
-              } /* create_file_cb */,
-              &sequence_number, log_size_for_flush);
+          db_options,
+          [&](const std::string& src_dirname, const std::string& fname,
+              FileType) {
+            ROCKS_LOG_INFO(db_options.info_log, "Hard Linking %s", fname.c_str());
+            return db_->GetEnv()->LinkFile(src_dirname + fname,
+                                            full_private_path + fname);
+          } /* link_file_cb */,
+          [&](const std::string& src_dirname, const std::string& fname,
+              uint64_t size_limit_bytes, FileType) {
+            ROCKS_LOG_INFO(db_options.info_log, "Copying %s", fname.c_str());
+            return CopyFile(db_->GetEnv(), src_dirname + fname,
+                            full_private_path + fname, size_limit_bytes,
+                            db_options.use_fsync);
+          } /* copy_file_cb */,
+          [&](const std::string& fname, const std::string& contents, FileType) {
+            ROCKS_LOG_INFO(db_options.info_log, "Creating %s", fname.c_str());
+            return CreateFile(db_->GetEnv(), full_private_path + fname, contents,
+                              db_options.use_fsync);
+          } /* create_file_cb */,
+          &sequence_number, log_size_for_flush, full_private_path);
     }
 
     if (disabled_file_deletions) {
-      // we copied all the files, enable file deletions
+      // We copied all the files, enable file deletions
       Status ss = db_->EnableFileDeletions(false);
       assert(ss.ok());
     }
-
   }
 
   if (s.ok()) {
-    // move tmp private backup to real checkpoint directory
+    // Move tmp private backup to real checkpoint directory
     s = db_->GetEnv()->RenameFile(full_private_path, checkpoint_dir);
   }
   if (s.ok()) {
@@ -140,12 +167,12 @@ Status TitanCheckpointImpl::CreateCheckpoint(const std::string& checkpoint_dir,
   }
 
   if (s.ok()) {
-    // here we know that we succeeded and installed the new checkpoint
+    // Here we know that we succeeded and installed the new checkpoint
     ROCKS_LOG_INFO(db_options.info_log, "Checkpoint DONE. All is good");
     ROCKS_LOG_INFO(db_options.info_log, "Checkpoint sequence number: %" PRIu64,
                    sequence_number);
   } else {
-    // clean all the files we might have created
+    // Clean all the files we might have created
     ROCKS_LOG_INFO(db_options.info_log, "Checkpoint failed -- %s",
                    s.ToString().c_str());
     CleanStagingDirectory(full_private_path, db_options.info_log.get());
@@ -154,209 +181,114 @@ Status TitanCheckpointImpl::CreateCheckpoint(const std::string& checkpoint_dir,
 }
 
 Status TitanCheckpointImpl::CreateCustomCheckpoint(
-        const DBOptions& db_options,
-        std::function<Status(const std::string& src_dirname,
-                             const std::string& src_fname, FileType type)>
-        link_file_cb,
-        std::function<Status(const std::string& src_dirname,
-                             const std::string& src_fname,
-                             uint64_t size_limit_bytes, FileType type)>
-        copy_file_cb,
-        std::function<Status(const std::string& fname, const std::string& contents,
-                             FileType type)>
-        create_file_cb,
-        uint64_t* sequence_number, uint64_t log_size_for_flush) {
+    const DBOptions& db_options,
+    std::function<Status(const std::string& src_dirname,
+                          const std::string& src_fname, FileType type)>
+    link_file_cb,
+    std::function<Status(const std::string& src_dirname,
+                          const std::string& src_fname,
+                          uint64_t size_limit_bytes, FileType type)>
+    copy_file_cb,
+    std::function<Status(const std::string& fname, const std::string& contents,
+                          FileType type)>
+    create_file_cb,
+    uint64_t* sequence_number, uint64_t log_size_for_flush,
+    const std::string full_private_path) {
   Status s;
-  std::vector<std::string> live_files;
-  std::vector<std::string> titan_live_files;
-  uint64_t base_manifest_file_size = 0;
-  uint64_t titan_manifest_file_size = 0;
-  uint64_t min_log_num = port::kMaxUint64;
-  *sequence_number = db_->GetLatestSequenceNumber();
+  std::vector<std::string> titandb_files;
+  std::vector<VersionEdit> version_edits;
   bool same_fs = true;
-  VectorLogPtr live_wal_files;
 
-  bool flush_memtable = true;
-  if (s.ok()) {
-    if (!db_options.allow_2pc) {
-      if (log_size_for_flush == port::kMaxUint64) {
-        flush_memtable = false;
-      } else if (log_size_for_flush > 0) {
-        // if out standing log files are small, we skip the flush.
-        s = db_->GetSortedWalFiles(live_wal_files);
+  // Create base db checkpoint
+  s = db_->DisableFileDeletions();
+  const bool disabled_file_deletions = s.ok();
 
-        if (!s.ok()) {
-          return s;
-        }
+  auto base_db_checkpoint = new rocksdb::CheckpointImpl(db_);
+  s = base_db_checkpoint->CreateCustomCheckpoint(
+      db_options, link_file_cb, copy_file_cb, create_file_cb, sequence_number,
+      log_size_for_flush);
+  delete base_db_checkpoint;
+  base_db_checkpoint = nullptr;
 
-        // Don't flush column families if total log size is smaller than
-        // log_size_for_flush. We copy the log files instead.
-        // We may be able to cover 2PC case too.
-        uint64_t total_wal_size = 0;
-        for (auto& wal : live_wal_files) {
-          total_wal_size += wal->SizeFileBytes();
-        }
-        if (total_wal_size < log_size_for_flush) {
-          flush_memtable = false;
-        }
-        live_wal_files.clear();
-      }
+  if (!s.ok()) {
+    if (disabled_file_deletions) {
+      Status ss = db_->EnableFileDeletions(false);
+      assert(ss.ok());
     }
-
-    // this will return live files prefixed with "/"
-    s = db_->GetTitanLiveFiles(live_files, &base_manifest_file_size,
-                               titan_live_files, &titan_manifest_file_size,
-                               flush_memtable);
-    
-    if (s.ok() && db_options.allow_2pc) {
-      // If 2PC is enabled, we need to get minimum log number after the flush.
-      // Need to refetch the live files to recapture the checkpoint.
-      if (!db_->GetIntProperty(DB::Properties::kMinLogNumberToKeep,
-                               &min_log_num)) {
-        return Status::InvalidArgument(
-                "2PC enabled but cannot fine the min log number to keep.");
-      }
-      // GetTitanLiveFiles() calls the rocksdb::DB::GetLiveFiles() internally.
-      // We need to refetch live files with flush to handle this case:
-      // A previous 000001.log contains the prepare record of transaction tnx1.
-      // The current log file is 000002.log, and sequence_number points to this
-      // file.
-      // After calling rocksdb::DB::GetLiveFiles(), 000003.log is created.
-      // Then tnx1 is committed. The commit record is written to 000003.log.
-      // Now we fetch min_log_num, which will be 3.
-      // Then only 000002.log and 000003.log will be copied, and 000001.log will
-      // be skipped. 000003.log contains commit message of tnx1, but we don't
-      // have respective prepare record for it.
-      // In order to avoid this situation, we need to force flush to make sure
-      // all transactions committed before getting min_log_num will be flushed
-      // to SST files.
-      // We cannot get min_log_num before calling the rocksdb::DB::GetLiveFiles()
-      // for the first time, because if we do that, all the logs files will be
-      // included, far more than needed.
-      s = db_->GetTitanLiveFiles(live_files, &base_manifest_file_size,
-                                 titan_live_files, &titan_manifest_file_size,
-                                 flush_memtable);
-    }
-
-    TEST_SYNC_POINT("TitanCheckpointImpl::CreateCheckpoint:SavedLiveFiles1");
-    TEST_SYNC_POINT("TitanCheckpointImpl::CreateCheckpoint:SavedLiveFiles2");
-    db_->FlushWAL(false /* sync */);
+    return s;
   }
-  // if we have more than one column family, we need to also get WAL files
-  if (s.ok()) {
-    s = db_->GetSortedWalFiles(live_wal_files);
+
+  // This will return files prefixed with "/titandb"
+  s = db_->GetAllTitanFiles(titandb_files, &version_edits);
+
+  if (disabled_file_deletions) {
+    Status ss = db_->EnableFileDeletions(false);
+    assert(ss.ok());
   }
+
+  TEST_SYNC_POINT(
+      "TitanCheckpointImpl::CreateCustomCheckpoint::AfterGetAllTitanFiles");
+  TEST_SYNC_POINT(
+      "TitanCheckpointImpl::CreateCustomCheckpoint:BeforeTitanDBCheckpoint1");
+  TEST_SYNC_POINT(
+      "TitanCheckpointImpl::CreateCustomCheckpoint::BeforeTitanDBCheckpoint2");
+
   if (!s.ok()) {
     return s;
   }
 
-  size_t wal_size = live_wal_files.size();
-
-  live_files.insert(live_files.end(), titan_live_files.begin(), titan_live_files.end());
-
-  // copy/hard link live_files
-  std::string base_manifest_fname, base_current_fname;
-  std::string titan_manifest_fname, titan_current_fname;
-  for (size_t i = 0; s.ok() && i < live_files.size(); ++i) {
+  // Copy/Hard link files
+  std::string manifest_fname, current_fname;
+  for (size_t i = 0; s.ok() && i < titandb_files.size(); ++i) {
     uint64_t number;
     FileType type;
-    bool ok, in_titan_dir = false;
-    // the filename prefix is '/titandb'
-    if (live_files[i].rfind("/titandb", 0) == 0) {
-      in_titan_dir = true;
-      ok = ParseFileName(live_files[i].substr(8), &number, &type);
-    } else {
-      ok = ParseFileName(live_files[i], &number, &type);
-    }
+    // Should remove '/titandb' prefix
+    bool ok = ParseFileName(titandb_files[i].substr(8), &number, &type);
 
     if (!ok) {
       s = Status::Corruption("Can't parse file name. This is very bad");
       break;
     }
-    // we should only get sst, blob, options, manifest and current files here
-    assert(type == kTableFile || type == kBlobFile || type == kDescriptorFile ||
-           type == kCurrentFile || type == kOptionsFile);
-    assert(live_files[i].size() > 0 && live_files[i][0] == '/');
+
+    // We should only get blob, manifest and current files here
+    assert(type == kBlobFile || type == kDescriptorFile ||
+           type == kCurrentFile);
+    assert(titandb_files[i].size() > 8 &&
+           titandb_files[i].substr(0, 8) == "/titandb");
     if (type == kCurrentFile) {
-      // We will craft the current file manually to ensure it's consistent with
-      // the manifest number. This is necessary because current's file contents
-      // can change during checkpoint creation.
-      if (in_titan_dir) {
-        titan_current_fname = live_files[i];
-      } else {
-        base_current_fname = live_files[i];
-      }
+      current_fname = titandb_files[i];
       continue;
     } else if (type == kDescriptorFile) {
-      if (in_titan_dir) {
-        titan_manifest_fname = live_files[i];
-      } else {
-        base_manifest_fname = live_files[i];
-      }
+      manifest_fname = titandb_files[i];
     }
-    std::string src_fname = live_files[i];
+    std::string src_fname = titandb_files[i];
 
-    // rules:
-    // * if it's kTableFile/kBlobFile, then it's shared
-    // * if it's kDescriptorFile, limit the size to manifest_file_size
-    // * always copy if cross-device link
-    if ((type == kTableFile || type == kBlobFile) && same_fs) {
+    // Rules:
+    // * If it's kBlobFile, then it's shared
+    // * If it's kDescriptorFile, craft the manifest based on all blob file
+    // * If it's kCurrentFile, craft the current file manually to ensure 
+    //   it's consistent with the manifest number. This is necessary because 
+    //   current file contents can change during checkpoint creation.
+    // * Always copy if cross-device link.
+    if (type == kBlobFile && same_fs) {
       s = link_file_cb(db_->GetName(), src_fname, type);
       if (s.IsNotSupported()) {
         same_fs = false;
         s = Status::OK();
       }
     }
-    if ((type != kTableFile && type != kBlobFile) || (!same_fs)) {
+    if (type != kBlobFile || !same_fs) {
       if (type == kDescriptorFile) {
-        s = copy_file_cb(db_->GetName(), src_fname,
-                (in_titan_dir) ? titan_manifest_file_size : base_manifest_file_size,
-                type);  
+        s = CreateTitanManifest(full_private_path + src_fname, &version_edits);
       } else {
-        s = copy_file_cb(db_->GetName(), src_fname, 0, type);        
+        s = copy_file_cb(db_->GetName(), src_fname, 0, type);
       }
     }
-    
   }
   // Write manifest name to CURRENT file
-  if (s.ok() && !base_current_fname.empty() && !base_manifest_fname.empty()) {
-    create_file_cb(base_current_fname, base_manifest_fname.substr(1) + "\n",
+  if (s.ok() && !current_fname.empty() && !manifest_fname.empty()) {
+    create_file_cb(current_fname, manifest_fname.substr(9) + "\n",
                    kCurrentFile);
-  }
-  if (s.ok() && !titan_current_fname.empty() && !titan_manifest_fname.empty()) {
-    create_file_cb(titan_current_fname, titan_manifest_fname.substr(8) + "\n",
-                   kCurrentFile);
-  }
-
-  ROCKS_LOG_INFO(db_options.info_log, "Number of log files %" ROCKSDB_PRIszt,
-                 live_wal_files.size());
-
-  // Link WAL files. Copy exact size of last one because it is the only one
-  // that has changes after the last flush.
-  for (size_t i = 0; s.ok() && i < wal_size; ++i) {
-    if ((live_wal_files[i]->Type() == kAliveLogFile) &&
-        (!flush_memtable ||
-         live_wal_files[i]->StartSequence() >= *sequence_number ||
-         live_wal_files[i]->LogNumber() >= min_log_num)) {
-      if (i + 1 == wal_size) {
-        s = copy_file_cb(db_options.wal_dir, live_wal_files[i]->PathName(),
-                         live_wal_files[i]->SizeFileBytes(), kLogFile);
-        break;
-      }
-      if (same_fs) {
-        // we only care about live log files
-        s = link_file_cb(db_options.wal_dir, live_wal_files[i]->PathName(),
-                         kLogFile);
-        if (s.IsNotSupported()) {
-          same_fs = false;
-          s = Status::OK();
-        }
-      }
-      if (!same_fs) {
-        s = copy_file_cb(db_options.wal_dir, live_wal_files[i]->PathName(), 0,
-                         kLogFile);
-      }
-    }
   }
 
   return s;

--- a/src/titan_checkpoint_impl.h
+++ b/src/titan_checkpoint_impl.h
@@ -22,10 +22,9 @@ class TitanCheckpointImpl : public Checkpoint {
   // and on restart Titan will recalculate GC stats and GC out those redundant
   // blob files.
   using Checkpoint::CreateCheckpoint;
-  virtual Status CreateCheckpoint(
-              const std::string& base_checkpoint_dir,
-              const std::string& titan_checkpoint_dir = "",
-              uint64_t log_size_for_flush = 0) override;
+  virtual Status CreateCheckpoint(const std::string& base_checkpoint_dir,
+                                  const std::string& titan_checkpoint_dir = "",
+                                  uint64_t log_size_for_flush = 0) override;
 
   // Checkpoint logic can be customized by providing callbacks for link, copy,
   // or create.

--- a/src/titan_checkpoint_impl.h
+++ b/src/titan_checkpoint_impl.h
@@ -20,7 +20,7 @@ class TitanCheckpointImpl : public Checkpoint {
   // (3) Create MANIFEST file include all records about existing blob files.
   // (4) Craft CURRENT file manually based on MANIFEST file number.
   // This will include redundant blob files, but hopefully not a lot of them,
-  // and on restart Titan will recalculate GC stats and GC out those redundant 
+  // and on restart Titan will recalculate GC stats and GC out those redundant
   // blob files.
   using Checkpoint::CreateCheckpoint;
   virtual Status CreateCheckpoint(const std::string& checkpoint_dir,
@@ -31,15 +31,15 @@ class TitanCheckpointImpl : public Checkpoint {
   Status CreateCustomCheckpoint(
       const DBOptions& db_options,
       std::function<Status(const std::string& src_dirname,
-                            const std::string& fname, FileType type)>
-      link_file_cb,
+                           const std::string& fname, FileType type)>
+          link_file_cb,
       std::function<Status(const std::string& src_dirname,
-                            const std::string& fname, uint64_t size_limit_bytes,
-                            FileType type)>
-      copy_file_cb,
+                           const std::string& fname, uint64_t size_limit_bytes,
+                           FileType type)>
+          copy_file_cb,
       std::function<Status(const std::string& fname,
-                            const std::string& contents, FileType type)>
-      create_file_cb,
+                           const std::string& contents, FileType type)>
+          create_file_cb,
       uint64_t* sequence_number, uint64_t log_size_for_flush,
       const std::string full_private_path);
 

--- a/src/titan_checkpoint_impl.h
+++ b/src/titan_checkpoint_impl.h
@@ -1,47 +1,54 @@
 #pragma once
 
-#include "titan/checkpoint.h"
-
 #include "file/filename.h"
+#include "titan/checkpoint.h"
 
 namespace rocksdb {
 namespace titandb {
 
+class VersionEdit;
+
 class TitanCheckpointImpl : public Checkpoint {
  public:
-  // Creates a Checkpoint object to be used for creating openable snapshots
   explicit TitanCheckpointImpl(TitanDB* db) : db_(db) {}
 
-  // Builds an openable snapshot of TitanDB on the same disk, which
-  // accepts an output directory on the same disk, and under the directory
-  // (1) hard-linked SST files pointing to existing live SST files
-  // SST files will be copied if output directory is on a different filesystem
-  // (2) a copied manifest files and other files
-  // The directory should not already exist and will be created by this API.
-  // The directory will be an absolute path
+  // Builds an openable snapshot of Titan on the same disk, which accepts
+  // an output directory on the same disk, and under the directory.
+  // (1) Create base db checkpoint.
+  // (2) Hard linked all existing blob files(live + obsolete) if the output
+  //     directory is on the same filesystem, and copied otherwise.
+  // (3) Create MANIFEST file include all records about existing blob files.
+  // (4) Craft CURRENT file manually based on MANIFEST file number.
+  // This will include redundant blob files, but hopefully not a lot of them,
+  // and on restart Titan will recalculate GC stats and GC out those redundant 
+  // blob files.
   using Checkpoint::CreateCheckpoint;
   virtual Status CreateCheckpoint(const std::string& checkpoint_dir,
                                   uint64_t log_size_for_flush) override;
 
-
   // Checkpoint logic can be customized by providing callbacks for link, copy,
   // or create.
   Status CreateCustomCheckpoint(
-          const DBOptions& db_options,
-          std::function<Status(const std::string& src_dirname,
-                               const std::string& fname, FileType type)>
-          link_file_cb,
-          std::function<Status(const std::string& src_dirname,
-                               const std::string& fname, uint64_t size_limit_bytes,
-                               FileType type)>
-          copy_file_cb,
-          std::function<Status(const std::string& fname,
-                               const std::string& contents, FileType type)>
-          create_file_cb,
-          uint64_t* sequence_number, uint64_t log_size_for_flush);
+      const DBOptions& db_options,
+      std::function<Status(const std::string& src_dirname,
+                            const std::string& fname, FileType type)>
+      link_file_cb,
+      std::function<Status(const std::string& src_dirname,
+                            const std::string& fname, uint64_t size_limit_bytes,
+                            FileType type)>
+      copy_file_cb,
+      std::function<Status(const std::string& fname,
+                            const std::string& contents, FileType type)>
+      create_file_cb,
+      uint64_t* sequence_number, uint64_t log_size_for_flush,
+      const std::string full_private_path);
 
  private:
   void CleanStagingDirectory(const std::string& path, Logger* info_log);
+
+  // Create titan manifest file based on the content of VersionEdit
+  Status CreateTitanManifest(const std::string& file_name,
+                             std::vector<VersionEdit>* edits);
 
  private:
   TitanDB* db_;

--- a/src/titan_checkpoint_impl.h
+++ b/src/titan_checkpoint_impl.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "titan/checkpoint.h"
+
+#include "file/filename.h"
+
+namespace rocksdb {
+namespace titandb {
+
+class TitanCheckpointImpl : public Checkpoint {
+ public:
+  // Creates a Checkpoint object to be used for creating openable snapshots
+  explicit TitanCheckpointImpl(TitanDB* db) : db_(db) {}
+
+  // Builds an openable snapshot of TitanDB on the same disk, which
+  // accepts an output directory on the same disk, and under the directory
+  // (1) hard-linked SST files pointing to existing live SST files
+  // SST files will be copied if output directory is on a different filesystem
+  // (2) a copied manifest files and other files
+  // The directory should not already exist and will be created by this API.
+  // The directory will be an absolute path
+  using Checkpoint::CreateCheckpoint;
+  virtual Status CreateCheckpoint(const std::string& checkpoint_dir,
+                                  uint64_t log_size_for_flush) override;
+
+
+  // Checkpoint logic can be customized by providing callbacks for link, copy,
+  // or create.
+  Status CreateCustomCheckpoint(
+          const DBOptions& db_options,
+          std::function<Status(const std::string& src_dirname,
+                               const std::string& fname, FileType type)>
+          link_file_cb,
+          std::function<Status(const std::string& src_dirname,
+                               const std::string& fname, uint64_t size_limit_bytes,
+                               FileType type)>
+          copy_file_cb,
+          std::function<Status(const std::string& fname,
+                               const std::string& contents, FileType type)>
+          create_file_cb,
+          uint64_t* sequence_number, uint64_t log_size_for_flush);
+
+ private:
+  void CleanStagingDirectory(const std::string& path, Logger* info_log);
+
+ private:
+  TitanDB* db_;
+};
+
+}  // namespace titandb
+}  // namespace rocksdb

--- a/src/titan_checkpoint_impl.h
+++ b/src/titan_checkpoint_impl.h
@@ -12,8 +12,7 @@ class TitanCheckpointImpl : public Checkpoint {
  public:
   explicit TitanCheckpointImpl(TitanDB* db) : db_(db) {}
 
-  // Builds an openable snapshot of Titan on the same disk, which accepts
-  // an output directory on the same disk, and under the directory.
+  // Follow these steps to build an openable snapshot of TitanDB:
   // (1) Create base db checkpoint.
   // (2) Hard linked all existing blob files(live + obsolete) if the output
   //     directory is on the same filesystem, and copied otherwise.
@@ -23,13 +22,15 @@ class TitanCheckpointImpl : public Checkpoint {
   // and on restart Titan will recalculate GC stats and GC out those redundant
   // blob files.
   using Checkpoint::CreateCheckpoint;
-  virtual Status CreateCheckpoint(const std::string& checkpoint_dir,
-                                  uint64_t log_size_for_flush) override;
+  virtual Status CreateCheckpoint(
+              const std::string& base_checkpoint_dir,
+              const std::string& titan_checkpoint_dir = "",
+              uint64_t log_size_for_flush = 0) override;
 
   // Checkpoint logic can be customized by providing callbacks for link, copy,
   // or create.
   Status CreateCustomCheckpoint(
-      const DBOptions& db_options,
+      const TitanDBOptions& titandb_options,
       std::function<Status(const std::string& src_dirname,
                            const std::string& fname, FileType type)>
           link_file_cb,
@@ -40,8 +41,7 @@ class TitanCheckpointImpl : public Checkpoint {
       std::function<Status(const std::string& fname,
                            const std::string& contents, FileType type)>
           create_file_cb,
-      uint64_t* sequence_number, uint64_t log_size_for_flush,
-      const std::string full_private_path);
+      uint64_t log_size_for_flush, const std::string full_private_path);
 
  private:
   void CleanStagingDirectory(const std::string& path, Logger* info_log);

--- a/src/titan_checkpoint_test.cc
+++ b/src/titan_checkpoint_test.cc
@@ -156,7 +156,8 @@ class CheckpointTest : public testing::Test {
     ASSERT_OK(DestroyTitanDB(dbname_, options));
   }
 
-  Status DestroyTitanDB(const std::string& dbname, const TitanOptions& options) {
+  Status DestroyTitanDB(const std::string& dbname,
+                        const TitanOptions& options) {
     // Clear and delete TitanDB directory first
     std::vector<std::string> filenames;
     std::string titandb_path;
@@ -166,7 +167,7 @@ class CheckpointTest : public testing::Test {
     } else {
       titandb_path = titan_options.dirname;
     }
-    
+
     // Ignore error in case directory does not exist
     env_->GetChildren(titandb_path, &filenames);
 
@@ -270,7 +271,8 @@ TEST_F(CheckpointTest, GetSnapshotLink) {
     // Take a snapshot
     Checkpoint* checkpoint;
     ASSERT_OK(Checkpoint::Create(db_, &checkpoint));
-    ASSERT_OK(checkpoint->CreateCheckpoint(snapshot_name_, "", log_size_for_flush));
+    ASSERT_OK(
+        checkpoint->CreateCheckpoint(snapshot_name_, "", log_size_for_flush));
     ASSERT_OK(Put(small_key, small_value_v2));
     ASSERT_EQ(small_value_v2, Get(small_key));
     ASSERT_OK(Put(large_key, large_value_v2));
@@ -334,7 +336,7 @@ TEST_F(CheckpointTest, SpecifyTitanCheckpointDirectory) {
 
   // Take a snapshot using a specific TitanDB directory
   Checkpoint* checkpoint;
-  std::string titandb_snapshot_dir = 
+  std::string titandb_snapshot_dir =
       test::PerThreadDBPath(env_, "snapshot-titandb");
   ASSERT_OK(Checkpoint::Create(db_, &checkpoint));
   ASSERT_OK(checkpoint->CreateCheckpoint(snapshot_name_, titandb_snapshot_dir));
@@ -565,10 +567,10 @@ TEST_F(CheckpointTest, CheckpointInvalidDirectoryName) {
     Checkpoint* checkpoint;
     ASSERT_OK(Checkpoint::Create(db_, &checkpoint));
     ASSERT_TRUE(
-      checkpoint->CreateCheckpoint(checkpoint_dir).IsInvalidArgument());
+        checkpoint->CreateCheckpoint(checkpoint_dir).IsInvalidArgument());
     if (!checkpoint_dir.empty()) {
-      ASSERT_TRUE(checkpoint->CreateCheckpoint(
-        snapshot_name_, checkpoint_dir).IsInvalidArgument());
+      ASSERT_TRUE(checkpoint->CreateCheckpoint(snapshot_name_, checkpoint_dir)
+                      .IsInvalidArgument());
     }
     delete checkpoint;
   }

--- a/src/titan_checkpoint_test.cc
+++ b/src/titan_checkpoint_test.cc
@@ -1,0 +1,531 @@
+#include <iostream>
+#include <thread>
+#include <utility>
+#include "titan/checkpoint.h"
+#include "titan/db.h"
+
+#include "port/port.h"
+#include "port/stack_trace.h"
+#include "rocksdb/env.h"
+#include "rocksdb/utilities/transaction_db.h"
+#include "test_util/fault_injection_test_env.h"
+#include "test_util/sync_point.h"
+#include "test_util/testharness.h"
+#include "test_util/testutil.h"
+
+namespace rocksdb {
+namespace titandb {
+
+class CheckpointTest : public testing::Test {
+ protected:
+  // Sequence of option configurations to try
+  enum OptionConfig {
+    kDefault = 0,
+  };
+  int option_config_;
+
+ public:
+  std::string dbname_;
+  std::string alternative_wal_dir_;
+  Env* env_;
+  TitanDB* db_;
+  TitanOptions last_options_;
+  std::vector<ColumnFamilyHandle*> handles_;
+  std::string snapshot_name_;
+
+  CheckpointTest() : env_(Env::Default()) {
+    env_->SetBackgroundThreads(1, Env::LOW);
+    env_->SetBackgroundThreads(1, Env::HIGH);
+    dbname_ = test::PerThreadDBPath(env_, "checkpoint_test");
+    // dbname_ = "./checkpoint_test";
+    alternative_wal_dir_ = dbname_ + "/wal";
+    auto options = CurrentOptions();
+    auto delete_options = options;
+    delete_options.wal_dir = alternative_wal_dir_;
+    EXPECT_OK(DestroyTitanDB(dbname_, delete_options));
+    // Destroy it for not alternative WAL dir is used.
+    EXPECT_OK(DestroyTitanDB(dbname_, options));
+    db_ = nullptr;
+    snapshot_name_ = test::PerThreadDBPath(env_, "snapshot");
+    // snapshot_name_ = "./snapshot";
+    std::string snapshot_tmp_name = snapshot_name_ + ".tmp";
+    EXPECT_OK(DestroyTitanDB(snapshot_name_, options));
+    env_->DeleteDir(snapshot_name_);
+    EXPECT_OK(DestroyTitanDB(snapshot_tmp_name, options));
+    env_->DeleteDir(snapshot_tmp_name);
+    Reopen(options);
+  }
+
+  ~CheckpointTest() override {
+    // rocksdb::SyncPoint::GetInstance()->DisableProcessing();
+    // rocksdb::SyncPoint::GetInstance()->LoadDependency({});
+    // rocksdb::SyncPoint::GetInstance()->ClearAllCallBacks();
+    
+    Close();
+    Options options;
+    options.db_paths.emplace_back(dbname_, 0);
+    options.db_paths.emplace_back(dbname_ + "_2", 0);
+    options.db_paths.emplace_back(dbname_ + "_3", 0);
+    options.db_paths.emplace_back(dbname_ + "_4", 0);
+    EXPECT_OK(DestroyTitanDB(dbname_, options));
+    EXPECT_OK(DestroyTitanDB(snapshot_name_, options));
+  }
+
+  // Return the current option configuration.
+  TitanOptions CurrentOptions() {
+    TitanOptions options;
+    options.dirname = dbname_ + "/titandb";
+    options.env = env_;
+    options.create_if_missing = true;
+    return options;
+  }
+
+  void CreateColumnFamilies(const std::vector<std::string>& cfs,
+                            const TitanOptions& options) {
+    ColumnFamilyOptions cf_opts(options);
+    size_t cfi = handles_.size();
+    handles_.resize(cfi + cfs.size());
+    for (auto cf : cfs) {
+      ASSERT_OK(db_->CreateColumnFamily(cf_opts, cf, &handles_[cfi++]));
+    }
+  }
+
+  void CreateAndReopenWithCF(const std::vector<std::string>& cfs,
+                             const TitanOptions& options) {
+    CreateColumnFamilies(cfs, options);
+    std::vector<std::string> cfs_plus_default = cfs;
+    cfs_plus_default.insert(cfs_plus_default.begin(), kDefaultColumnFamilyName);
+    ReopenWithColumnFamilies(cfs_plus_default, options);
+  }
+
+  void ReopenWithColumnFamilies(const std::vector<std::string>& cfs,
+                                const std::vector<TitanOptions>& options) {
+    ASSERT_OK(TryReopenWithColumnFamilies(cfs, options));
+  }
+
+  void ReopenWithColumnFamilies(const std::vector<std::string>& cfs,
+                                const TitanOptions& options) {
+    ASSERT_OK(TryReopenWithColumnFamilies(cfs, options));
+  }
+
+  Status TryReopenWithColumnFamilies(
+      const std::vector<std::string>& cfs,
+      const std::vector<TitanOptions>& options) {
+    Close();
+    EXPECT_EQ(cfs.size(), options.size());
+    std::vector<TitanCFDescriptor> column_families;
+    for (size_t i = 0; i < cfs.size(); ++i) {
+      column_families.push_back(TitanCFDescriptor(cfs[i], options[i]));
+    }
+    TitanDBOptions db_opts = TitanDBOptions(options[0]);
+    return TitanDB::Open(db_opts, dbname_, column_families, &handles_, &db_);
+  }
+
+  Status TryReopenWithColumnFamilies(const std::vector<std::string>& cfs,
+                                     const TitanOptions& options) {
+    Close();
+    std::vector<TitanOptions> v_opts(cfs.size(), options);
+    return TryReopenWithColumnFamilies(cfs, v_opts);
+  }
+
+  void Reopen(const TitanOptions& options) {
+    ASSERT_OK(TryReopen(options));
+  }
+
+  void CompactAll() {
+    for (auto h : handles_) {
+      ASSERT_OK(db_->CompactRange(CompactRangeOptions(), h, nullptr, nullptr));
+    }
+  }
+
+  void Close() {
+    for (auto h : handles_) {
+      delete h;
+    }
+    handles_.clear();
+    delete db_;
+    db_ = nullptr;
+  }
+
+  void DestroyAndReopen(const TitanOptions& options) {
+    // Destroy using last options
+    Destroy(last_options_);
+    ASSERT_OK(TryReopen(options));
+  }
+
+  void Destroy(const Options& options) {
+    Close();
+    ASSERT_OK(DestroyTitanDB(dbname_, options));
+  }
+
+  Status DestroyTitanDB(const std::string& dbname, const Options& options) {
+    // clear and delete titandb directory first
+    std::vector<std::string> filenames;
+    std::string titandb_path = dbname + "/titandb";
+    // ignore error in case directory does not exist
+    env_->GetChildren(titandb_path, &filenames);
+    
+    for (auto& fname : filenames) {
+      std::string file_path = titandb_path + "/" + fname;
+      env_->DeleteFile(file_path);
+    } 
+  
+    env_->DeleteDir(titandb_path);
+    // then destroy base db
+    return DestroyDB(dbname, options);
+  }
+
+  Status TryReopen(const TitanOptions& options) {
+    Close();
+    last_options_ = options;
+    return TitanDB::Open(options, dbname_, &db_);
+  }
+
+  Status Flush(int cf = 0) {
+    if (cf == 0) {
+      return db_->Flush(FlushOptions());
+    } else {
+      return db_->Flush(FlushOptions(), handles_[cf]);
+    }
+  }
+
+  Status Put(const Slice& k, const Slice& v, WriteOptions wo = WriteOptions()) {
+    return db_->Put(wo, k, v);
+  }
+
+  Status Put(int cf, const Slice& k, const Slice& v,
+             WriteOptions wo = WriteOptions()) {
+    return db_->Put(wo, handles_[cf], k, v);
+  }
+
+  Status Delete(const std::string& k) {
+    return db_->Delete(WriteOptions(), k);
+  }
+
+  Status Delete(int cf, const std::string& k) {
+    return db_->Delete(WriteOptions(), handles_[cf], k);
+  }
+
+  std::string Get(const std::string& k, const Snapshot* snapshot = nullptr) {
+    ReadOptions options;
+    options.verify_checksums = true;
+    options.snapshot = snapshot;
+    std::string result;
+    Status s = db_->Get(options, k, &result);
+    if (s.IsNotFound()) {
+      result = "NOT_FOUND";
+    } else if (!s.ok()) {
+      result = s.ToString();
+    }
+    return result;
+  }
+
+  std::string Get(int cf, const std::string& k,
+                  const Snapshot* snapshot = nullptr) {
+    ReadOptions options;
+    options.verify_checksums = true;
+    options.snapshot = snapshot;
+    std::string result;
+    Status s = db_->Get(options, handles_[cf], k, &result);
+    if (s.IsNotFound()) {
+      result = "NOT_FOUND";
+    } else if (!s.ok()) {
+      result = s.ToString();
+    }
+    return result;
+  }
+};
+
+TEST_F(CheckpointTest, GetSnapshotLink) {
+  for (uint64_t log_size_for_flush : {0, 1000000}) {
+    Options options;
+    TitanDB* snapshotDB;
+    ReadOptions roptions;
+    std::string result;
+    Checkpoint* checkpoint;
+    options = CurrentOptions();
+    delete db_;
+    db_ = nullptr;
+    ASSERT_OK(DestroyTitanDB(dbname_, options));
+
+    // Create a database
+    Status s;
+    options.create_if_missing = true;
+    ASSERT_OK(TitanDB::Open(TitanOptions(options), dbname_, &db_));
+    
+    std::string key = std::string("foo");
+    ASSERT_OK(Put(key, "v1"));
+    ASSERT_EQ("v1", Get(key));
+    // Take a snapshot
+    ASSERT_OK(Checkpoint::Create(db_, &checkpoint));
+    ASSERT_OK(checkpoint->CreateCheckpoint(snapshot_name_, log_size_for_flush));
+    ASSERT_OK(Put(key, "v2"));
+    ASSERT_EQ("v2", Get(key));
+    ASSERT_OK(Flush());
+    ASSERT_EQ("v2", Get(key));
+    // Open snapshot and verify contents while DB is running
+    options.create_if_missing = false;
+    ASSERT_OK(TitanDB::Open(TitanOptions(options), snapshot_name_, &snapshotDB));
+    ASSERT_OK(snapshotDB->Get(roptions, key, &result));
+    ASSERT_EQ("v1", result);
+    delete snapshotDB;
+    snapshotDB = nullptr;
+    delete db_;
+    db_ = nullptr;
+    // Destroy original DB
+    ASSERT_OK(DestroyTitanDB(dbname_, options));
+    // Open snapshot and verify contents
+    options.create_if_missing = false;
+    dbname_ = snapshot_name_;
+    ASSERT_OK(TitanDB::Open(TitanOptions(options), dbname_, &db_));
+    ASSERT_EQ("v1", Get(key));
+    delete db_;
+    db_ = nullptr;
+    ASSERT_OK(DestroyTitanDB(dbname_, options));
+    delete checkpoint;
+    // Restore DB name
+    dbname_ = test::PerThreadDBPath(env_, "db_test");
+  }
+}
+
+TEST_F(CheckpointTest, CheckpointCF) {
+  TitanOptions options = CurrentOptions();
+  CreateAndReopenWithCF({"one", "two", "three", "four", "five"}, options);
+  // rocksdb::SyncPoint::GetInstance()->LoadDependency(
+  //     {{"CheckpointTest::CheckpointCF:2", "DBImpl::GetLiveFiles:2"},
+  //      {"DBImpl::GetLiveFiles:1", "CheckpointTest::CheckpointCF:1"}});
+
+  // rocksdb::SyncPoint::GetInstance()->EnableProcessing();
+
+  ASSERT_OK(Put(0, "Default", "Default"));
+  ASSERT_OK(Put(1, "one", "one"));
+  ASSERT_OK(Put(2, "two", "two"));
+  ASSERT_OK(Put(3, "three", "three"));
+  ASSERT_OK(Put(4, "four", "four"));
+  ASSERT_OK(Put(5, "five", "five"));
+
+  DB* snapshotDB;
+  ReadOptions roptions;
+  std::string result;
+  std::vector<ColumnFamilyHandle*> cphandles;
+
+  Status s;
+  // Take a snapshot
+  rocksdb::port::Thread t([&]() {
+    Checkpoint* checkpoint;
+    ASSERT_OK(Checkpoint::Create(db_, &checkpoint));
+    ASSERT_OK(checkpoint->CreateCheckpoint(snapshot_name_));
+    delete checkpoint;
+  });
+  TEST_SYNC_POINT("CheckpointTest::CheckpointCF:1");
+  ASSERT_OK(Put(0, "Default", "Default1"));
+  ASSERT_OK(Put(1, "one", "eleven"));
+  ASSERT_OK(Put(2, "two", "twelve"));
+  ASSERT_OK(Put(3, "three", "thirteen"));
+  ASSERT_OK(Put(4, "four", "fourteen"));
+  ASSERT_OK(Put(5, "five", "fifteen"));
+  TEST_SYNC_POINT("CheckpointTest::CheckpointCF:2");
+  t.join();
+  // rocksdb::SyncPoint::GetInstance()->DisableProcessing();
+  ASSERT_OK(Put(1, "one", "twentyone"));
+  ASSERT_OK(Put(2, "two", "twentytwo"));
+  ASSERT_OK(Put(3, "three", "twentythree"));
+  ASSERT_OK(Put(4, "four", "twentyfour"));
+  ASSERT_OK(Put(5, "five", "twentyfive"));
+  ASSERT_OK(Flush());
+
+  // Open snapshot and verify contents while DB is running
+  options.create_if_missing = false;
+  std::vector<std::string> cfs;
+  cfs=  {kDefaultColumnFamilyName, "one", "two", "three", "four", "five"};
+  std::vector<ColumnFamilyDescriptor> column_families;
+    for (size_t i = 0; i < cfs.size(); ++i) {
+      column_families.push_back(ColumnFamilyDescriptor(cfs[i], options));
+    }
+  ASSERT_OK(DB::Open(options, snapshot_name_,
+        column_families, &cphandles, &snapshotDB));
+  ASSERT_OK(snapshotDB->Get(roptions, cphandles[0], "Default", &result));
+  ASSERT_EQ("Default1", result);
+  ASSERT_OK(snapshotDB->Get(roptions, cphandles[1], "one", &result));
+  ASSERT_EQ("eleven", result);
+  ASSERT_OK(snapshotDB->Get(roptions, cphandles[2], "two", &result));
+  for (auto h : cphandles) {
+      delete h;
+  }
+  cphandles.clear();
+  delete snapshotDB;
+  snapshotDB = nullptr;
+}
+
+TEST_F(CheckpointTest, CheckpointCFNoFlush) {
+  TitanOptions options = CurrentOptions();
+  CreateAndReopenWithCF({"one", "two", "three", "four", "five"}, options);
+
+  // rocksdb::SyncPoint::GetInstance()->EnableProcessing();
+
+  ASSERT_OK(Put(0, "Default", "Default"));
+  ASSERT_OK(Put(1, "one", "one"));
+  Flush();
+  ASSERT_OK(Put(2, "two", "two"));
+
+  DB* snapshotDB;
+  ReadOptions roptions;
+  std::string result;
+  std::vector<ColumnFamilyHandle*> cphandles;
+
+  Status s;
+  // Take a snapshot
+  // rocksdb::SyncPoint::GetInstance()->SetCallBack(
+  //     "DBImpl::BackgroundCallFlush:start", [&](void* /*arg*/) {
+  //       // Flush should never trigger.
+  //       FAIL();
+  //     });
+  // rocksdb::SyncPoint::GetInstance()->EnableProcessing();
+  Checkpoint* checkpoint;
+  ASSERT_OK(Checkpoint::Create(db_, &checkpoint));
+  ASSERT_OK(checkpoint->CreateCheckpoint(snapshot_name_, 1000000));
+  // rocksdb::SyncPoint::GetInstance()->DisableProcessing();
+
+  delete checkpoint;
+  ASSERT_OK(Put(1, "one", "two"));
+  ASSERT_OK(Flush(1));
+  ASSERT_OK(Put(2, "two", "twentytwo"));
+  Close();
+  EXPECT_OK(DestroyTitanDB(dbname_, options));
+
+  // Open snapshot and verify contents while DB is running
+  options.create_if_missing = false;
+  std::vector<std::string> cfs;
+  cfs = {kDefaultColumnFamilyName, "one", "two", "three", "four", "five"};
+  std::vector<ColumnFamilyDescriptor> column_families;
+  for (size_t i = 0; i < cfs.size(); ++i) {
+    column_families.push_back(ColumnFamilyDescriptor(cfs[i], options));
+  }
+  ASSERT_OK(DB::Open(options, snapshot_name_, column_families, &cphandles,
+                     &snapshotDB));
+  ASSERT_OK(snapshotDB->Get(roptions, cphandles[0], "Default", &result));
+  ASSERT_EQ("Default", result);
+  ASSERT_OK(snapshotDB->Get(roptions, cphandles[1], "one", &result));
+  ASSERT_EQ("one", result);
+  ASSERT_OK(snapshotDB->Get(roptions, cphandles[2], "two", &result));
+  ASSERT_EQ("two", result);
+  for (auto h : cphandles) {
+    delete h;
+  }
+  cphandles.clear();
+  delete snapshotDB;
+  snapshotDB = nullptr;
+}
+
+TEST_F(CheckpointTest, CurrentFileModifiedWhileCheckpointing) {
+  TitanOptions options = CurrentOptions();
+  options.max_manifest_file_size = 0;  // always rollover manifest for file add
+  Reopen(options);
+
+  // rocksdb::SyncPoint::GetInstance()->LoadDependency(
+  //     {// Get past the flush in the checkpoint thread before adding any keys to
+  //      // the db so the checkpoint thread won't hit the WriteManifest
+  //      // syncpoints.
+  //      {"DBImpl::GetLiveFiles:1",
+  //       "CheckpointTest::CurrentFileModifiedWhileCheckpointing:PrePut"},
+  //      // Roll the manifest during checkpointing right after live files are
+  //      // snapshotted.
+  //      {"CheckpointImpl::CreateCheckpoint:SavedLiveFiles1",
+  //       "VersionSet::LogAndApply:WriteManifest"},
+  //      {"VersionSet::LogAndApply:WriteManifestDone",
+  //       "CheckpointImpl::CreateCheckpoint:SavedLiveFiles2"}});
+  // rocksdb::SyncPoint::GetInstance()->EnableProcessing();
+
+  rocksdb::port::Thread t([&]() {
+    Checkpoint* checkpoint;
+    ASSERT_OK(Checkpoint::Create(db_, &checkpoint));
+    ASSERT_OK(checkpoint->CreateCheckpoint(snapshot_name_));
+    delete checkpoint;
+  });
+  TEST_SYNC_POINT(
+      "CheckpointTest::CurrentFileModifiedWhileCheckpointing:PrePut");
+  ASSERT_OK(Put("Default", "Default1"));
+  ASSERT_OK(Flush());
+  t.join();
+
+  // rocksdb::SyncPoint::GetInstance()->DisableProcessing();
+
+  DB* snapshotDB;
+  // Successful Open() implies that CURRENT pointed to the manifest in the
+  // checkpoint.
+  ASSERT_OK(DB::Open(options, snapshot_name_, &snapshotDB));
+  delete snapshotDB;
+  snapshotDB = nullptr;
+}
+
+
+TEST_F(CheckpointTest, CheckpointInvalidDirectoryName) {
+  for (std::string checkpoint_dir : {"", "/", "////"}) {
+    Checkpoint* checkpoint;
+    ASSERT_OK(Checkpoint::Create(db_, &checkpoint));
+    ASSERT_TRUE(checkpoint->CreateCheckpoint("").IsInvalidArgument());
+    delete checkpoint;
+  }
+}
+
+TEST_F(CheckpointTest, CheckpointWithParallelWrites) {
+  // When run with TSAN, this exposes the data race fixed in
+  // https://github.com/facebook/rocksdb/pull/3603
+  ASSERT_OK(Put("key1", "val1"));
+  port::Thread thread([this]() { ASSERT_OK(Put("key2", "val2")); });
+  Checkpoint* checkpoint;
+  ASSERT_OK(Checkpoint::Create(db_, &checkpoint));
+  ASSERT_OK(checkpoint->CreateCheckpoint(snapshot_name_));
+  delete checkpoint;
+  thread.join();
+}
+
+TEST_F(CheckpointTest, CheckpointWithUnsyncedDataDropped) {
+  TitanOptions options = CurrentOptions();
+  FaultInjectionTestEnv *p = new FaultInjectionTestEnv(env_);
+  std::unique_ptr<FaultInjectionTestEnv> env(p);
+  // std::unique_ptr<FaultInjectionTestEnv> env(new FaultInjectionTestEnv(env_));
+  options.env = env.get();
+  Reopen(options);
+  ASSERT_OK(Put("key1", "val1"));
+  Checkpoint* checkpoint;
+  ASSERT_OK(Checkpoint::Create(db_, &checkpoint));
+  ASSERT_OK(checkpoint->CreateCheckpoint(snapshot_name_));
+  delete checkpoint;
+  // env->DropUnsyncedFileData();
+
+  // make sure it's openable even though whatever data that wasn't synced got
+  // dropped.
+  options.env = env_;
+  DB* snapshot_db;
+  ASSERT_OK(DB::Open(options, snapshot_name_, &snapshot_db));
+  ReadOptions read_opts;
+  std::string get_result;
+  ASSERT_OK(snapshot_db->Get(read_opts, "key1", &get_result));
+  ASSERT_EQ("val1", get_result);
+  delete snapshot_db;
+  delete db_;
+  db_ = nullptr;
+}
+
+// TEST_F(CheckpointTest, MyTest) {
+//   FaultInjectionTestEnv *p = new FaultInjectionTestEnv(env_);
+//   ASSERT_TRUE(p->IsFilesystemActive());
+//   p->setFilesystemActive();
+//   ASSERT_TRUE(p->IsFilesystemActive());
+//   std::unique_ptr<FaultInjectionTestEnv> env(p);
+//   TitanOptions options = CurrentOptions();
+//   options.env = env.get();
+//   ASSERT_TRUE(p->IsFilesystemActive());
+// }
+
+}  // namespace titandb
+}  // namespace rocksdb
+
+int main(int argc, char** argv) {
+  rocksdb::port::InstallStackTraceHandler();
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+


### PR DESCRIPTION
I added checkpoint support for Titan inspired by [tikv/rocksdb](https://github.com/tikv/rocksdb/tree/6.4.tikv/).

The basic idea is:
1. Create a new, separate directory for checkpoint
2. Call `TitanDB::DisableFileDeletions` to disable delete operations
3. Call `rocksdb::CheckpointImpl::CreateCheckpoint` to create base db checkpoint
4. Call `TitanDB::GetAllTitanFiles()` to collect all existing files and record all existing blob file in `titandb::VersionEdit version_edit`
5. For all existing files: 
    - If the Checkpoint directory and the source database directory are on the same file system, hard linked blob files, otherwise copy them
    - For the MANIFEST file, create it based on `version_edit`, which will prevent removing useful blob file when Titan reopen 
    - For the CURRENT file, read the name of the MANIFEST file and write it into the CURRENT file
6. Call `TitanDB::EnableFileDeletions()` to restore deletion

This will include redundant blob files in the checkpoint, but hopefully not a lot of them, Titan will recalculate GC stats and GC out those redundant blob files on restart.