### PR TITLE
Fix the titan invalid ratelimiter in Flush/GC

### DIFF
--- a/src/blob_file_manager.h
+++ b/src/blob_file_manager.h
@@ -26,7 +26,8 @@ class BlobFileManager {
   // Creates a new file. The new file should not be accessed until
   // FinishFile() has been called.
   // If successful, sets "*handle* to the new file handle.
-  virtual Status NewFile(std::unique_ptr<BlobFileHandle>* handle) = 0;
+  virtual Status NewFile(std::unique_ptr<BlobFileHandle>* handle,
+                         Env::IOPriority pri = Env::IOPriority::IO_LOW) = 0;
 
   // Finishes the file with the provided metadata. Stops writting to
   // the file anymore.

--- a/src/blob_file_manager.h
+++ b/src/blob_file_manager.h
@@ -26,6 +26,7 @@ class BlobFileManager {
   // Creates a new file. The new file should not be accessed until
   // FinishFile() has been called.
   // If successful, sets "*handle* to the new file handle.
+  // And also, sets the IOPriority to the new file handle.
   virtual Status NewFile(std::unique_ptr<BlobFileHandle>* handle,
                          Env::IOPriority pri = Env::IOPriority::IO_LOW) = 0;
 

--- a/src/blob_file_manager.h
+++ b/src/blob_file_manager.h
@@ -25,10 +25,14 @@ class BlobFileManager {
 
   // Creates a new file. The new file should not be accessed until
   // FinishFile() has been called.
-  // If successful, sets "*handle* to the new file handle.
-  // And also, sets the IOPriority to the new file handle.
+  // If successful, sets "*handle* to the new file handle with given
+  // IOPriority.
+  //
+  // The reason why set the io priority for WritableFile in Flush,
+  // Compaction and GC is that the ratelimiter will use the default
+  // priority IO_TOTAL which won't be limited in ratelimiter.
   virtual Status NewFile(std::unique_ptr<BlobFileHandle>* handle,
-                         Env::IOPriority pri = Env::IOPriority::IO_LOW) = 0;
+                         Env::IOPriority pri = Env::IOPriority::IO_TOTAL) = 0;
 
   // Finishes the file with the provided metadata. Stops writting to
   // the file anymore.

--- a/src/blob_gc_job.cc
+++ b/src/blob_gc_job.cc
@@ -211,7 +211,7 @@ Status BlobGCJob::DoRunGC() {
             std::move(blob_file_handle), std::move(blob_file_builder)));
       }
       // Set the GC's blob file with a low_io pri in ratelimiter
-      s = blob_file_manager_->NewFile(&blob_file_handle, 
+      s = blob_file_manager_->NewFile(&blob_file_handle,
                                       Env::IOPriority::IO_LOW);
       if (!s.ok()) {
         break;

--- a/src/blob_gc_job.cc
+++ b/src/blob_gc_job.cc
@@ -210,7 +210,9 @@ Status BlobGCJob::DoRunGC() {
         blob_file_builders_.emplace_back(std::make_pair(
             std::move(blob_file_handle), std::move(blob_file_builder)));
       }
-      s = blob_file_manager_->NewFile(&blob_file_handle);
+      // Set the GC's blob file with a low_io pri in ratelimiter
+      s = blob_file_manager_->NewFile(&blob_file_handle, 
+                                      Env::IOPriority::IO_LOW);
       if (!s.ok()) {
         break;
       }

--- a/src/blob_gc_job.cc
+++ b/src/blob_gc_job.cc
@@ -210,7 +210,6 @@ Status BlobGCJob::DoRunGC() {
         blob_file_builders_.emplace_back(std::make_pair(
             std::move(blob_file_handle), std::move(blob_file_builder)));
       }
-      // Set the GC's blob file with a low_io pri in ratelimiter
       s = blob_file_manager_->NewFile(&blob_file_handle,
                                       Env::IOPriority::IO_LOW);
       if (!s.ok()) {

--- a/src/blob_gc_job_test.cc
+++ b/src/blob_gc_job_test.cc
@@ -294,7 +294,8 @@ TEST_P(BlobGCJobTest, GCLimiter) {
     size_t RequestToken(size_t bytes, size_t alignment,
                         Env::IOPriority io_priority, Statistics* stats,
                         RateLimiter::OpType op_type) override {
-      if (IsRateLimited(op_type)) {
+      // Just the same condition with the rocksdb's RequestToken
+      if (io_priority < Env::IO_TOTAL && IsRateLimited(op_type)) {
         if (op_type == RateLimiter::OpType::kRead) {
           read = true;
         } else {

--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -30,7 +30,7 @@ class TitanDBImpl::FileManager : public BlobFileManager {
   FileManager(TitanDBImpl* db) : db_(db) {}
 
   Status NewFile(std::unique_ptr<BlobFileHandle>* handle,
-                 Env:IOPriority pri) override {
+                 Env::IOPriority pri) override {
     auto number = db_->blob_file_set_->NewFileNumber();
     auto name = BlobFileName(db_->dirname_, number);
 

--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -41,11 +41,7 @@ class TitanDBImpl::FileManager : public BlobFileManager {
       s = db_->env_->NewWritableFile(name, &f, db_->env_options_);
       if (!s.ok()) return s;
 
-      // Set the io priority for WritableFile in Flush or GC.
-      // Or the ratelimiter will use the default priority IO_ALL
-      // which won't be limited in ratelimiter.
       f->SetIOPriority(pri);
-
       file.reset(new WritableFileWriter(std::move(f), name, db_->env_options_));
     }
 

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -146,7 +146,7 @@ void TitanTableBuilder::AddBlob(const ParsedInternalKey& ikey,
 
   // Init blob_builder_ first
   if (!blob_builder_) {
-    // Set the GC's blob file with a high_io pri in ratelimiter
+    // Set the Flush's blob file with a high_io pri in ratelimiter
     status_ = blob_manager_->NewFile(&blob_handle_, Env::IOPriority::IO_HIGH);
     if (!ok()) return;
     ROCKS_LOG_INFO(db_options_.info_log,

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -146,7 +146,8 @@ void TitanTableBuilder::AddBlob(const ParsedInternalKey& ikey,
 
   // Init blob_builder_ first
   if (!blob_builder_) {
-    status_ = blob_manager_->NewFile(&blob_handle_);
+    // Set the GC's blob file with a high_io pri in ratelimiter
+    status_ = blob_manager_->NewFile(&blob_handle_, Env::IOPriority::IO_HIGH);
     if (!ok()) return;
     ROCKS_LOG_INFO(db_options_.info_log,
                    "Titan table builder created new blob file %" PRIu64 ".",

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -146,8 +146,11 @@ void TitanTableBuilder::AddBlob(const ParsedInternalKey& ikey,
 
   // Init blob_builder_ first
   if (!blob_builder_) {
-    // Set the Flush's blob file with a high_io pri in ratelimiter
-    status_ = blob_manager_->NewFile(&blob_handle_, Env::IOPriority::IO_HIGH);
+    // Set the Flush's blob file with a high_io pri  and the Compaction's
+    // Blob file with a low_io pri in ratelimiter.
+    status_ = blob_manager_->NewFile(
+        &blob_handle_,
+        target_level_ > 0 ? Env::IOPriority::IO_LOW : Env::IOPriority::IO_HIGH);
     if (!ok()) return;
     ROCKS_LOG_INFO(db_options_.info_log,
                    "Titan table builder created new blob file %" PRIu64 ".",

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -147,7 +147,7 @@ void TitanTableBuilder::AddBlob(const ParsedInternalKey& ikey,
   // Init blob_builder_ first
   if (!blob_builder_) {
     // Set the Flush's blob file with a high_io pri  and the Compaction's
-    // Blob file with a low_io pri in ratelimiter.
+    // blob file with a low_io pri in ratelimiter.
     status_ = blob_manager_->NewFile(
         &blob_handle_,
         target_level_ > 0 ? Env::IOPriority::IO_LOW : Env::IOPriority::IO_HIGH);

--- a/src/table_builder_test.cc
+++ b/src/table_builder_test.cc
@@ -24,7 +24,8 @@ class FileManager : public BlobFileManager {
         number_(kTestFileNumber),
         blob_file_set_(blob_file_set) {}
 
-  Status NewFile(std::unique_ptr<BlobFileHandle>* handle) override {
+  Status NewFile(std::unique_ptr<BlobFileHandle>* handle,
+                 Env::IOPriority pri = Env::IOPriority::IO_LOW) override {
     auto number = number_.fetch_add(1);
     auto name = BlobFileName(db_options_.dirname, number);
     std::unique_ptr<WritableFileWriter> file;
@@ -32,6 +33,7 @@ class FileManager : public BlobFileManager {
       std::unique_ptr<WritableFile> f;
       Status s = env_->NewWritableFile(name, &f, env_options_);
       if (!s.ok()) return s;
+      f->SetIOPriority(pri);
       file.reset(new WritableFileWriter(std::move(f), name, env_options_));
     }
     handle->reset(new FileHandle(number, name, std::move(file)));

--- a/src/table_builder_test.cc
+++ b/src/table_builder_test.cc
@@ -25,7 +25,7 @@ class FileManager : public BlobFileManager {
         blob_file_set_(blob_file_set) {}
 
   Status NewFile(std::unique_ptr<BlobFileHandle>* handle,
-                 Env::IOPriority pri = Env::IOPriority::IO_LOW) override {
+                 Env::IOPriority pri = Env::IOPriority::IO_TOTAL) override {
     auto number = number_.fetch_add(1);
     auto name = BlobFileName(db_options_.dirname, number);
     std::unique_ptr<WritableFileWriter> file;


### PR DESCRIPTION
Fix #209 ;

And the different `io_priority_` when  invoke a`NewFile` to create  the blobfile.

We always want limit the compaction/gc's write IO to keep the latency of read, so i keep the Flush with `IO_HIGH` pri and set the GC wich `IO_LOW` pri.

zhanghuigui@kuaishou.com