### PR TITLE
Optimize Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: cpp
 
 os: linux
 compiler: clang
-osx_image: xcode12.2
 
 addons:
   apt:
@@ -24,7 +23,6 @@ addons:
       - lz4
       - snappy
       - xz
-    update: true
 
 env:
   - BUILD_TYPE="Release"
@@ -34,13 +32,6 @@ env:
 
 # For GCC build, we also report code coverage to codecov.
 matrix:
-  exclude:
-    - os: osx
-      env: SANITIZER="TSAN"
-    - os: osx
-      env: SANITIZER="UBSAN"
-    - os: osx
-      env: BUILD_TYPE="Release"
   include:
     - os: linux
       compiler:
@@ -51,6 +42,7 @@ matrix:
       env:
         - SANITIZER="ASAN"
     - os: osx
+      osx_image: xcode12.2
       env:
         - SANITIZER="ASAN"
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,10 @@ addons:
       - libzstd-dev
       - lcov
       - zlib1g
-  homebrew:
-    packages:
-      - gflags
-      - zstd
-      - lz4
-      - snappy
-      - xz
+
+stages:
+  - format
+  - test
 
 env:
   - BUILD_TYPE="Release"
@@ -32,6 +29,7 @@ env:
 
 # For GCC build, we also report code coverage to codecov.
 matrix:
+  fast_finish: true
   include:
     - os: linux
       compiler:
@@ -45,12 +43,24 @@ matrix:
       osx_image: xcode12.2
       env:
         - SANITIZER="ASAN"
-    - os: linux
+    - stage: format
+      os: linux
       compiler:
       env:
         - FORMATTER=ON
 
 install:
+  # Don't do package update because Travis homebrew aren't cached.
+  - if [ "${TRAVIS_OS_NAME}" == osx ]; then
+      to_install=( "gflags" "zstd" "lz4" "snappy" "xz" );
+      brew list > tmp;
+      for ins in ${to_install[*]}; do
+        grep -q "$ins" tmp;
+        if [ $? -ne 0 ]; then
+          brew install "$ins";
+        fi
+      done
+    fi
   - export CTEST_OUTPUT_ON_FAILURE=1
   - if [ "${COMPILER}" == gcc9 ]; then
       CC=gcc-9;

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ addons:
       - lz4
       - snappy
       - xz
+    update: true
 
 env:
   - BUILD_TYPE="Release"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,13 @@ addons:
       - libzstd-dev
       - lcov
       - zlib1g
+  homebrew:
+    packages:
+      - gflags
+      - zstd
+      - lz4
+      - snappy
+      - xz
 
 env:
   - BUILD_TYPE="Release"
@@ -51,17 +58,6 @@ matrix:
         - FORMATTER=ON
 
 install:
-  # osx dependencies
-  - if [ "${TRAVIS_OS_NAME}" == osx ]; then
-      to_install=( "gflags" "zstd" "lz4" "snappy" "xz" );
-      brew list > tmp;
-      for ins in ${to_install[*]}; do
-        grep -q "$ins" tmp;
-        if [ $? -ne 0 ]; then
-          brew install "$ins";
-        fi
-      done
-    fi
   - export CTEST_OUTPUT_ON_FAILURE=1
   - if [ "${COMPILER}" == gcc9 ]; then
       CC=gcc-9;

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,16 +31,16 @@ env:
 matrix:
   fast_finish: true
   include:
+    - os: osx
+      osx_image: xcode12.2
+      env:
+        - SANITIZER="ASAN"
     - os: linux
       compiler:
       env:
         - COMPILER=gcc9
     - os: linux
       arch: arm64
-      env:
-        - SANITIZER="ASAN"
-    - os: osx
-      osx_image: xcode12.2
       env:
         - SANITIZER="ASAN"
     - stage: format
@@ -53,7 +53,7 @@ install:
   # Don't do package update because Travis homebrew aren't cached.
   - if [ "${TRAVIS_OS_NAME}" == osx ]; then
       to_install=( "gflags" "zstd" "lz4" "snappy" "xz" );
-      brew list > tmp;
+      brew list --formula > tmp;
       for ins in ${to_install[*]}; do
         grep -q "$ins" tmp;
         if [ $? -ne 0 ]; then


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

In our CI mac build, homebrew update often timeout. Mitigate this issue by upgrading Xcode image (spec was ineffective before).
Also optimize build time by adding format stage and fail_fast flag so that failed test can trigger immediate termination.