### PR TITLE
Fix missing obsolete sequence for deletion in deleteblobfiles

### DIFF
--- a/src/blob_file_set.cc
+++ b/src/blob_file_set.cc
@@ -287,7 +287,7 @@ Status BlobFileSet::DeleteBlobFilesInRanges(uint32_t cf_id,
     Status s = it->second->GetBlobFilesInRanges(ranges, n, include_end, &files);
     if (!s.ok()) return s;
     for (auto file_number : files) {
-      edit.DeleteBlobFile(file_number);
+      edit.DeleteBlobFile(file_number, obsolete_sequence);
     }
     s = LogAndApply(edit);
     return s;

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -728,6 +728,10 @@ TEST_F(TitanDBTest, DeleteFilesInRange) {
   ASSERT_TRUE(db_->GetProperty("rocksdb.num-files-at-level6", &value));
   ASSERT_EQ(value, "3");
 
+  std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+  iter->SeekToFirst();
+  ASSERT_TRUE(iter->Valid());
+
   std::string key40 = GenKey(40);
   std::string key80 = GenKey(80);
   Slice start = Slice(key40);
@@ -748,6 +752,18 @@ TEST_F(TitanDBTest, DeleteFilesInRange) {
   // These two files are marked obsolete directly by `DeleteBlobFilesInRanges`
   ASSERT_EQ(blob->NumObsoleteBlobFiles(), 2);
 
+  // The snapshot held by the iterator prevents the blob files from being
+  // purged.
+  ASSERT_OK(db_impl_->TEST_PurgeObsoleteFiles());
+  while (iter->Valid()) {
+    iter->Next();
+    ASSERT_OK(iter->status());
+  }
+  ASSERT_EQ(blob->NumBlobFiles(), 6);
+  ASSERT_EQ(blob->NumObsoleteBlobFiles(), 2);
+
+  // Once the snapshot is released, the blob files should be purged.
+  iter.reset(nullptr);
   ASSERT_OK(db_impl_->TEST_PurgeObsoleteFiles());
   ASSERT_EQ(blob->NumBlobFiles(), 4);
   ASSERT_EQ(blob->NumObsoleteBlobFiles(), 0);

--- a/src/version_edit.cc
+++ b/src/version_edit.cc
@@ -69,7 +69,7 @@ Status VersionEdit::DecodeFrom(Slice* src) {
         break;
       case kDeletedBlobFile:
         if (GetVarint64(src, &file_number)) {
-          DeleteBlobFile(file_number);
+          DeleteBlobFile(file_number, 0);
         } else {
           error = "deleted blob file";
         }

--- a/src/version_edit.h
+++ b/src/version_edit.h
@@ -32,8 +32,7 @@ class VersionEdit {
     added_files_.push_back(file);
   }
 
-  void DeleteBlobFile(uint64_t file_number,
-                      SequenceNumber obsolete_sequence = 0) {
+  void DeleteBlobFile(uint64_t file_number, SequenceNumber obsolete_sequence) {
     deleted_files_.emplace_back(std::make_pair(file_number, obsolete_sequence));
   }
 

--- a/src/version_test.cc
+++ b/src/version_test.cc
@@ -134,8 +134,8 @@ TEST_F(VersionTest, VersionEdit) {
   auto file2 = std::make_shared<BlobFileMeta>(5, 6, 0, 0, "", "");
   input.AddBlobFile(file1);
   input.AddBlobFile(file2);
-  input.DeleteBlobFile(7);
-  input.DeleteBlobFile(8);
+  input.DeleteBlobFile(7, 0);
+  input.DeleteBlobFile(8, 0);
   CheckCodec(input);
 }
 
@@ -153,7 +153,7 @@ VersionEdit DeleteBlobFilesEdit(uint32_t cf_id, uint64_t start, uint64_t end) {
   VersionEdit edit;
   edit.SetColumnFamilyID(cf_id);
   for (auto i = start; i < end; i++) {
-    edit.DeleteBlobFile(i);
+    edit.DeleteBlobFile(i, 0);
   }
   return edit;
 }
@@ -367,7 +367,7 @@ TEST_F(VersionTest, BlobFileMetaV1ToV2) {
   VersionEdit edit;
   edit.SetColumnFamilyID(1);
   edit.AddBlobFile(std::make_shared<BlobFileMeta>(1, 1, 0, 0, "", ""));
-  edit.DeleteBlobFile(1);
+  edit.DeleteBlobFile(1, 0);
   edit.AddBlobFile(std::make_shared<BlobFileMeta>(2, 2, 0, 0, "", ""));
   std::string str;
   LegacyEncode(edit, &str);


### PR DESCRIPTION
When doing DeleteBlobFilesInRange, it shouldn't purge the blob files immediately, otherwise, the existing snapshots will be broken and cause `Missing Blob` errors.

![image](https://user-images.githubusercontent.com/13497871/118767473-60a34600-b8b0-11eb-875e-76f5c8cf040e.png)


To solve that, Titan introduces the obsolete sequence to make sure the blob files are purged only after the snapshots are released.  But in `DeleteBlobFilesInRange`, the obsolete sequence is not set, which breaks the promise.