### PR TITLE
Fix rocksdb logging macro

### DIFF
--- a/src/blob_gc_picker.cc
+++ b/src/blob_gc_picker.cc
@@ -6,6 +6,8 @@
 
 #include <inttypes.h>
 
+#include "titan_logging.h"
+
 namespace rocksdb {
 namespace titandb {
 
@@ -34,7 +36,7 @@ std::unique_ptr<BlobGC> BasicBlobGCPicker::PickBlobGC(
     if (!CheckBlobFile(blob_file.get())) {
       // Skip this file id this file is being GCed
       // or this file had been GCed
-      ROCKS_LOG_INFO(db_options_.info_log, "Blob file %" PRIu64 " no need gc",
+      TITAN_LOG_INFO(db_options_.info_log, "Blob file %" PRIu64 " no need gc",
                      blob_file->file_number());
       continue;
     }
@@ -53,7 +55,7 @@ std::unique_ptr<BlobGC> BasicBlobGCPicker::PickBlobGC(
       if (next_gc_size > cf_options_.min_gc_batch_size) {
         maybe_continue_next_time = true;
         RecordTick(statistics(stats_), TITAN_GC_REMAIN, 1);
-        ROCKS_LOG_INFO(db_options_.info_log,
+        TITAN_LOG_INFO(db_options_.info_log,
                        "remain more than %" PRIu64
                        " bytes to be gc and trigger after this gc",
                        next_gc_size);
@@ -61,7 +63,7 @@ std::unique_ptr<BlobGC> BasicBlobGCPicker::PickBlobGC(
       }
     }
   }
-  ROCKS_LOG_DEBUG(db_options_.info_log,
+  TITAN_LOG_DEBUG(db_options_.info_log,
                   "got batch size %" PRIu64 ", estimate output %" PRIu64
                   " bytes",
                   batch_size, estimate_output_size);

--- a/src/blob_storage.cc
+++ b/src/blob_storage.cc
@@ -1,5 +1,7 @@
 #include "blob_storage.h"
+
 #include "blob_file_set.h"
+#include "titan_logging.h"
 
 namespace rocksdb {
 namespace titandb {
@@ -58,7 +60,7 @@ Status BlobStorage::GetBlobFilesInRanges(const RangePtr* ranges, size_t n,
       assert(it->second->smallest_key().empty() ||
              (!begin || cmp->Compare(it->second->smallest_key(), *begin) >= 0));
     }
-    ROCKS_LOG_INFO(
+    TITAN_LOG_INFO(
         db_options_.info_log,
         "Get %" PRIuPTR " blob files [%s] in the range [%s, %s%c",
         files->size(), tmp.c_str(), begin ? begin->ToString(true).c_str() : " ",
@@ -171,7 +173,7 @@ void BlobStorage::GetObsoleteFiles(std::vector<std::string>* obsolete_files,
       // remove obsolete files
       bool __attribute__((__unused__)) removed = RemoveFile(file_number);
       assert(removed);
-      ROCKS_LOG_INFO(db_options_.info_log,
+      TITAN_LOG_INFO(db_options_.info_log,
                      "Obsolete blob file %" PRIu64 " (obsolete at %" PRIu64
                      ") not visible to oldest snapshot %" PRIu64 ", delete it.",
                      file_number, obsolete_sequence, oldest_sequence);

--- a/src/compaction_filter.h
+++ b/src/compaction_filter.h
@@ -5,6 +5,7 @@
 
 #include "db_impl.h"
 #include "rocksdb/compaction_filter.h"
+#include "titan_logging.h"
 #include "util/mutexlock.h"
 
 namespace rocksdb {
@@ -48,7 +49,7 @@ class TitanCompactionFilter final : public CompactionFilter {
     Slice original_value(value.data());
     Status s = blob_index.DecodeFrom(&original_value);
     if (!s.ok()) {
-      ROCKS_LOG_ERROR(db_->db_options_.info_log,
+      TITAN_LOG_ERROR(db_->db_options_.info_log,
                       "[%s] Unable to decode blob index", cf_name_.c_str());
       // TODO(yiwu): Better to fail the compaction as well, but current
       // compaction filter API doesn't support it.

--- a/src/db_impl_files.cc
+++ b/src/db_impl_files.cc
@@ -1,4 +1,5 @@
 #include "db_impl.h"
+#include "titan_logging.h"
 
 namespace rocksdb {
 namespace titandb {
@@ -26,12 +27,12 @@ Status TitanDBImpl::PurgeObsoleteFilesImpl() {
       candidate_files.end());
 
   for (const auto& candidate_file : candidate_files) {
-    ROCKS_LOG_INFO(db_options_.info_log, "Titan deleting obsolete file [%s]",
+    TITAN_LOG_INFO(db_options_.info_log, "Titan deleting obsolete file [%s]",
                    candidate_file.c_str());
     Status delete_status = env_->DeleteFile(candidate_file);
     if (!s.ok()) {
       // Move on despite error deleting the file.
-      ROCKS_LOG_ERROR(db_options_.info_log,
+      TITAN_LOG_ERROR(db_options_.info_log,
                       "Titan deleting file [%s] failed, status:%s",
                       candidate_file.c_str(), s.ToString().c_str());
       s = delete_status;

--- a/src/db_impl_gc.cc
+++ b/src/db_impl_gc.cc
@@ -1,11 +1,10 @@
-#include "db_impl.h"
-
-#include "test_util/sync_point.h"
-
 #include "blob_file_iterator.h"
 #include "blob_file_size_collector.h"
 #include "blob_gc_job.h"
 #include "blob_gc_picker.h"
+#include "db_impl.h"
+#include "test_util/sync_point.h"
+#include "titan_logging.h"
 #include "util.h"
 
 namespace rocksdb {
@@ -175,7 +174,7 @@ Status TitanDBImpl::BackgroundGC(LogBuffer* log_buffer,
     blob_storage = blob_file_set_->GetBlobStorage(column_family_id).lock();
   } else {
     TEST_SYNC_POINT_CALLBACK("TitanDBImpl::BackgroundGC:CFDropped", nullptr);
-    ROCKS_LOG_BUFFER(log_buffer, "GC skip dropped colum family [%s].",
+    TITAN_LOG_BUFFER(log_buffer, "GC skip dropped colum family [%s].",
                      cf_info_[column_family_id].name.c_str());
   }
   if (blob_storage != nullptr) {
@@ -199,7 +198,7 @@ Status TitanDBImpl::BackgroundGC(LogBuffer* log_buffer,
   if (UNLIKELY(!blob_gc)) {
     RecordTick(statistics(stats_.get()), TITAN_GC_NO_NEED, 1);
     // Nothing to do
-    ROCKS_LOG_BUFFER(log_buffer, "Titan GC nothing to do");
+    TITAN_LOG_BUFFER(log_buffer, "Titan GC nothing to do");
   } else {
     StopWatch gc_sw(env_, statistics(stats_.get()), TITAN_GC_MICROS);
     BlobGCJob blob_gc_job(blob_gc.get(), db_, &mutex_, db_options_,
@@ -236,7 +235,7 @@ Status TitanDBImpl::BackgroundGC(LogBuffer* log_buffer,
   } else {
     SetBGError(s);
     RecordTick(statistics(stats_.get()), TITAN_GC_FAILURE, 1);
-    ROCKS_LOG_WARN(db_options_.info_log, "Titan GC error: %s",
+    TITAN_LOG_WARN(db_options_.info_log, "Titan GC error: %s",
                    s.ToString().c_str());
   }
 

--- a/src/db_iter.h
+++ b/src/db_iter.h
@@ -10,9 +10,8 @@
 #include <unordered_map>
 
 #include "db/db_iter.h"
-#include "logging/logging.h"
 #include "rocksdb/env.h"
-
+#include "titan_logging.h"
 #include "titan_stats.h"
 
 namespace rocksdb {
@@ -135,7 +134,7 @@ class TitanDBIterator : public Iterator {
     BlobIndex index;
     status_ = DecodeInto(iter_->value(), &index);
     if (!status_.ok()) {
-      ROCKS_LOG_ERROR(info_log_,
+      TITAN_LOG_ERROR(info_log_,
                       "Titan iterator: failed to decode blob index %s: %s",
                       iter_->value().ToString(true /*hex*/).c_str(),
                       status_.ToString().c_str());
@@ -153,7 +152,7 @@ class TitanDBIterator : public Iterator {
       } else {
         status_ = DecodeInto(iter_->value(), &index);
         if (!status_.ok()) {
-          ROCKS_LOG_ERROR(info_log_,
+          TITAN_LOG_ERROR(info_log_,
                           "Titan iterator: failed to decode blob index %s: %s",
                           iter_->value().ToString(true /*hex*/).c_str(),
                           status_.ToString().c_str());
@@ -170,7 +169,7 @@ class TitanDBIterator : public Iterator {
       std::unique_ptr<BlobFilePrefetcher> prefetcher;
       status_ = storage_->NewPrefetcher(index.file_number, &prefetcher);
       if (!status_.ok()) {
-        ROCKS_LOG_ERROR(
+        TITAN_LOG_ERROR(
             info_log_,
             "Titan iterator: failed to create prefetcher for blob file %" PRIu64
             ": %s",
@@ -183,7 +182,7 @@ class TitanDBIterator : public Iterator {
     buffer_.Reset();
     status_ = it->second->Get(options_, index.blob_handle, &record_, &buffer_);
     if (!status_.ok()) {
-      ROCKS_LOG_ERROR(
+      TITAN_LOG_ERROR(
           info_log_,
           "Titan iterator: failed to read blob value from file %" PRIu64
           ", offset %" PRIu64 ", size %" PRIu64 ": %s\n",

--- a/src/edit_collector.h
+++ b/src/edit_collector.h
@@ -6,6 +6,7 @@
 #include <unordered_map>
 
 #include "blob_file_set.h"
+#include "titan_logging.h"
 #include "util/string_util.h"
 #include "version_edit.h"
 
@@ -144,13 +145,13 @@ class EditCollector {
         auto blob = storage->FindFile(number).lock();
         if (blob) {
           if (blob->is_obsolete()) {
-            ROCKS_LOG_ERROR(storage->db_options().info_log,
+            TITAN_LOG_ERROR(storage->db_options().info_log,
                             "blob file %" PRIu64 " has been deleted before\n",
                             number);
             return Status::Corruption("Blob file " + ToString(number) +
                                       " has been deleted before");
           } else {
-            ROCKS_LOG_ERROR(storage->db_options().info_log,
+            TITAN_LOG_ERROR(storage->db_options().info_log,
                             "blob file %" PRIu64 " has been added before\n",
                             number);
             return Status::Corruption("Blob file " + ToString(number) +
@@ -166,13 +167,13 @@ class EditCollector {
         }
         auto blob = storage->FindFile(number).lock();
         if (!blob) {
-          ROCKS_LOG_ERROR(storage->db_options().info_log,
+          TITAN_LOG_ERROR(storage->db_options().info_log,
                           "blob file %" PRIu64 " doesn't exist before\n",
                           number);
           return Status::Corruption("Blob file " + ToString(number) +
                                     " doesn't exist before");
         } else if (blob->is_obsolete()) {
-          ROCKS_LOG_ERROR(storage->db_options().info_log,
+          TITAN_LOG_ERROR(storage->db_options().info_log,
                           "blob file %" PRIu64 " has been deleted already\n",
                           number);
           return Status::Corruption("Blob file " + ToString(number) +

--- a/src/options.cc
+++ b/src/options.cc
@@ -6,25 +6,25 @@
 
 #include <inttypes.h>
 
-#include "logging/logging.h"
 #include "options/options_helper.h"
 #include "rocksdb/convenience.h"
+#include "titan_logging.h"
 
 namespace rocksdb {
 namespace titandb {
 
 void TitanDBOptions::Dump(Logger* logger) const {
-  ROCKS_LOG_HEADER(logger, "TitanDBOptions.dirname                    : %s",
+  TITAN_LOG_HEADER(logger, "TitanDBOptions.dirname                    : %s",
                    dirname.c_str());
-  ROCKS_LOG_HEADER(logger, "TitanDBOptions.disable_background_gc      : %d",
+  TITAN_LOG_HEADER(logger, "TitanDBOptions.disable_background_gc      : %d",
                    static_cast<int>(disable_background_gc));
-  ROCKS_LOG_HEADER(logger,
+  TITAN_LOG_HEADER(logger,
                    "TitanDBOptions.max_background_gc          : %" PRIi32,
                    max_background_gc);
-  ROCKS_LOG_HEADER(logger,
+  TITAN_LOG_HEADER(logger,
                    "TitanDBOptions.purge_obsolete_files_period_sec: %" PRIu32,
                    purge_obsolete_files_period_sec);
-  ROCKS_LOG_HEADER(logger,
+  TITAN_LOG_HEADER(logger,
                    "TitanDBOptions.titan_stats_dump_period_sec: %" PRIu32,
                    titan_stats_dump_period_sec);
 }
@@ -48,7 +48,7 @@ TitanCFOptions::TitanCFOptions(const ColumnFamilyOptions& cf_opts,
           immutable_opts.skip_value_in_compaction_filter) {}
 
 void TitanCFOptions::Dump(Logger* logger) const {
-  ROCKS_LOG_HEADER(logger,
+  TITAN_LOG_HEADER(logger,
                    "TitanCFOptions.min_blob_size                : %" PRIu64,
                    min_blob_size);
   std::string compression_str = "unknown";
@@ -58,45 +58,45 @@ void TitanCFOptions::Dump(Logger* logger) const {
       break;
     }
   }
-  ROCKS_LOG_HEADER(logger, "TitanCFOptions.blob_file_compression        : %s",
+  TITAN_LOG_HEADER(logger, "TitanCFOptions.blob_file_compression        : %s",
                    compression_str.c_str());
-  ROCKS_LOG_HEADER(logger, "TItanCFOptions.blob_file_compression_options: ");
-  ROCKS_LOG_HEADER(logger, "    window_bits : %d",
+  TITAN_LOG_HEADER(logger, "TItanCFOptions.blob_file_compression_options: ");
+  TITAN_LOG_HEADER(logger, "    window_bits : %d",
                    blob_file_compression_options.window_bits);
-  ROCKS_LOG_HEADER(logger, "    level : %d",
+  TITAN_LOG_HEADER(logger, "    level : %d",
                    blob_file_compression_options.level);
-  ROCKS_LOG_HEADER(logger, "    strategy : %d",
+  TITAN_LOG_HEADER(logger, "    strategy : %d",
                    blob_file_compression_options.strategy);
-  ROCKS_LOG_HEADER(logger, "    max_dict_bytes : %" PRIu32,
+  TITAN_LOG_HEADER(logger, "    max_dict_bytes : %" PRIu32,
                    blob_file_compression_options.max_dict_bytes);
-  ROCKS_LOG_HEADER(logger, "    zstd_max_train_bytes : %" PRIu32,
+  TITAN_LOG_HEADER(logger, "    zstd_max_train_bytes : %" PRIu32,
                    blob_file_compression_options.zstd_max_train_bytes);
-  ROCKS_LOG_HEADER(logger,
+  TITAN_LOG_HEADER(logger,
                    "TitanCFOptions.blob_file_target_size        : %" PRIu64,
                    blob_file_target_size);
-  ROCKS_LOG_HEADER(logger, "TitanCFOptions.blob_cache                   : %p",
+  TITAN_LOG_HEADER(logger, "TitanCFOptions.blob_cache                   : %p",
                    blob_cache.get());
   if (blob_cache != nullptr) {
-    ROCKS_LOG_HEADER(logger, "%s", blob_cache->GetPrintableOptions().c_str());
+    TITAN_LOG_HEADER(logger, "%s", blob_cache->GetPrintableOptions().c_str());
   }
-  ROCKS_LOG_HEADER(logger,
+  TITAN_LOG_HEADER(logger,
                    "TitanCFOptions.max_gc_batch_size            : %" PRIu64,
                    max_gc_batch_size);
-  ROCKS_LOG_HEADER(logger,
+  TITAN_LOG_HEADER(logger,
                    "TitanCFOptions.min_gc_batch_size            : %" PRIu64,
                    min_gc_batch_size);
-  ROCKS_LOG_HEADER(logger, "TitanCFOptions.blob_file_discardable_ratio  : %lf",
+  TITAN_LOG_HEADER(logger, "TitanCFOptions.blob_file_discardable_ratio  : %lf",
                    blob_file_discardable_ratio);
-  ROCKS_LOG_HEADER(logger, "TitanCFOptions.sample_file_size_ratio       : %lf",
+  TITAN_LOG_HEADER(logger, "TitanCFOptions.sample_file_size_ratio       : %lf",
                    sample_file_size_ratio);
-  ROCKS_LOG_HEADER(logger,
+  TITAN_LOG_HEADER(logger,
                    "TitanCFOptions.merge_small_file_threshold   : %" PRIu64,
                    merge_small_file_threshold);
   std::string blob_run_mode_str = "unknown";
   if (blob_run_mode_to_string.count(blob_run_mode) > 0) {
     blob_run_mode_str = blob_run_mode_to_string.at(blob_run_mode);
   }
-  ROCKS_LOG_HEADER(logger, "TitanCFOptions.blob_run_mode                : %s",
+  TITAN_LOG_HEADER(logger, "TitanCFOptions.blob_run_mode                : %s",
                    blob_run_mode_str.c_str());
 }
 

--- a/src/titan_logging.h
+++ b/src/titan_logging.h
@@ -1,0 +1,71 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+//
+// Must not be included from any .h files to avoid polluting the namespace
+// with macros.
+
+#pragma once
+
+// This file is adapted from rocksdb/logging/logging.h.
+// We make a copy of this file because we want to have source files under
+// Titan directory being shorten.
+
+// Helper macros that include information about file name and line number
+#define TITAN_LOG_STRINGIFY(x) #x
+#define TITAN_LOG_TOSTRING(x) TITAN_LOG_STRINGIFY(x)
+#define TITAN_LOG_PREPEND_FILE_LINE(FMT) \
+  ("[%s:" TITAN_LOG_TOSTRING(__LINE__) "] " FMT)
+
+inline const char* TitanLogShorterFileName(const char* file) {
+  // 15 is the length of "titan_logging.h".
+  // If the name of this file changed, please change this number, too.
+  return file + (sizeof(__FILE__) > 15 ? sizeof(__FILE__) - 15 : 0);
+}
+
+// Don't inclide file/line info in HEADER level
+#define TITAN_LOG_HEADER(LGR, FMT, ...) \
+  rocksdb::Log(InfoLogLevel::HEADER_LEVEL, LGR, FMT, ##__VA_ARGS__)
+
+#define TITAN_LOG_DEBUG(LGR, FMT, ...)           \
+  rocksdb::Log(InfoLogLevel::DEBUG_LEVEL, LGR,   \
+               TITAN_LOG_PREPEND_FILE_LINE(FMT), \
+               TitanLogShorterFileName(__FILE__), ##__VA_ARGS__)
+
+#define TITAN_LOG_INFO(LGR, FMT, ...)            \
+  rocksdb::Log(InfoLogLevel::INFO_LEVEL, LGR,    \
+               TITAN_LOG_PREPEND_FILE_LINE(FMT), \
+               TitanLogShorterFileName(__FILE__), ##__VA_ARGS__)
+
+#define TITAN_LOG_WARN(LGR, FMT, ...)            \
+  rocksdb::Log(InfoLogLevel::WARN_LEVEL, LGR,    \
+               TITAN_LOG_PREPEND_FILE_LINE(FMT), \
+               TitanLogShorterFileName(__FILE__), ##__VA_ARGS__)
+
+#define TITAN_LOG_ERROR(LGR, FMT, ...)           \
+  rocksdb::Log(InfoLogLevel::ERROR_LEVEL, LGR,   \
+               TITAN_LOG_PREPEND_FILE_LINE(FMT), \
+               TitanLogShorterFileName(__FILE__), ##__VA_ARGS__)
+
+#define TITAN_LOG_FATAL(LGR, FMT, ...)           \
+  rocksdb::Log(InfoLogLevel::FATAL_LEVEL, LGR,   \
+               TITAN_LOG_PREPEND_FILE_LINE(FMT), \
+               TitanLogShorterFileName(__FILE__), ##__VA_ARGS__)
+
+#define TITAN_LOG_BUFFER(LOG_BUF, FMT, ...)                       \
+  rocksdb::LogToBuffer(LOG_BUF, TITAN_LOG_PREPEND_FILE_LINE(FMT), \
+                       TitanLogShorterFileName(__FILE__), ##__VA_ARGS__)
+
+#define TITAN_LOG_BUFFER_MAX_SZ(LOG_BUF, MAX_LOG_SIZE, FMT, ...) \
+  rocksdb::LogToBuffer(LOG_BUF, MAX_LOG_SIZE,                    \
+                       TITAN_LOG_PREPEND_FILE_LINE(FMT),         \
+                       TitanLogShorterFileName(__FILE__), ##__VA_ARGS__)
+
+#define TITAN_LOG_DETAILS(LGR, FMT, ...) \
+  ;  // due to overhead by default skip such lines
+// TITAN_LOG_DEBUG(LGR, FMT, ##__VA_ARGS__)


### PR DESCRIPTION
This change is to fix ASAN test failure in CI.

The rocksdb logging.h file provides the ROCKS_LOG_XXX logging macro, and it contain a logic to shorten the source file being print. It use the length of its file path (e.g. "/path/to/rocksdb/logging/logging.h")  to truncate other source file path. Since Titan source could be in different directory, Titan source file path could be truncated incorrectly, or even cause out-of-range access to the string buffer. Copying the file into titan repo and make a Titan version of the macros to fix the problem.

Also doing clang format.

Signed-off-by: Yi Wu <yiwu@pingcap.com>