### PR TITLE
Link pthread in sanitizer builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,22 @@ if (CODE_COVERAGE)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
 endif()
 
+set(COMMON_LIBS
+  titan
+  rocksdb)
+
+if(WITH_ASAN OR WITH_TSAN)
+  find_package(Threads)
+  if(CMAKE_USE_PTHREADS_INIT)
+    link_libraries(pthread)
+  endif()
+endif()
+
+message("COMMON_LIBS " ${COMMON_LIBS})
+message("THREAD " ${CMAKE_THREAD_LIBS_INIT})
+message("PTHREAD " ${CMAKE_USE_PTHREADS_INIT})
+message("cmake " ${CMAKE_VERSION})
+
 if (WITH_TITAN_TESTS OR WITH_TITAN_TOOLS)
   add_subdirectory(${ROCKSDB_DIR} rocksdb EXCLUDE_FROM_ALL)
   # -latomic is needed when building titandb_stress using clang.
@@ -109,8 +125,7 @@ if (WITH_TITAN_TESTS AND (NOT CMAKE_BUILD_TYPE STREQUAL "Release"))
         compaction_filter_test
         version_test)
   set(TEST_LIBS
-        titan
-        rocksdb
+        ${COMMON_LIBS}
         testutillib
         gtest)
 
@@ -122,9 +137,7 @@ if (WITH_TITAN_TESTS AND (NOT CMAKE_BUILD_TYPE STREQUAL "Release"))
 endif()
 
 if (WITH_TITAN_TOOLS)
-  set(TOOLS_LIBS
-        titan
-        rocksdb)
+  set(TOOLS_LIBS ${COMMON_LIBS})
 
   if (NOT TRAVIS)
     find_package(gflags REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,11 +89,6 @@ if(WITH_ASAN OR WITH_TSAN)
   endif()
 endif()
 
-message("COMMON_LIBS " ${COMMON_LIBS})
-message("THREAD " ${CMAKE_THREAD_LIBS_INIT})
-message("PTHREAD " ${CMAKE_USE_PTHREADS_INIT})
-message("cmake " ${CMAKE_VERSION})
-
 if (WITH_TITAN_TESTS OR WITH_TITAN_TOOLS)
   add_subdirectory(${ROCKSDB_DIR} rocksdb EXCLUDE_FROM_ALL)
   # -latomic is needed when building titandb_stress using clang.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,7 @@ if (NOT DEFINED ROCKSDB_DIR)
   message(FATAL_ERROR "ROCKSDB_DIR is not defined.")
 endif()
 
-set(CMAKE_MODULE_PATH "${ROCKSDB_DIR}/cmake/modules/")
-# list(APPEND CMAKE_MODULE_PATH "${ROCKSDB_DIR}/cmake/modules/")
+get_filename_component(CMAKE_MODULE_PATH "${ROCKSDB_DIR}/cmake/modules/" ABSOLUTE)
 include(cmake/rocksdb_flags.cmake)
 
 include_directories(${ROCKSDB_DIR})

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -798,7 +798,7 @@ TEST_F(TitanDBTest, VersionEditError) {
 }
 
 #ifndef NDEBUG
-TEST_F(TitanDBTest, BlobFileIOError) {
+TEST_F(TitanDBTest, DISABED_BlobFileIOError) {
   std::unique_ptr<TitanFaultInjectionTestEnv> mock_env(
       new TitanFaultInjectionTestEnv(env_));
   options_.env = mock_env.get();

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -798,7 +798,7 @@ TEST_F(TitanDBTest, VersionEditError) {
 }
 
 #ifndef NDEBUG
-TEST_F(TitanDBTest, DISABED_BlobFileIOError) {
+TEST_F(TitanDBTest, DISABLED_BlobFileIOError) {
   std::unique_ptr<TitanFaultInjectionTestEnv> mock_env(
       new TitanFaultInjectionTestEnv(env_));
   options_.env = mock_env.get();

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -798,7 +798,7 @@ TEST_F(TitanDBTest, VersionEditError) {
 }
 
 #ifndef NDEBUG
-TEST_F(TitanDBTest, DISABLED_BlobFileIOError) {
+TEST_F(TitanDBTest, BlobFileIOError) {
   std::unique_ptr<TitanFaultInjectionTestEnv> mock_env(
       new TitanFaultInjectionTestEnv(env_));
   options_.env = mock_env.get();

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -1987,7 +1987,7 @@ TEST_F(TitanDBTest, Config) {
 }
 
 #if defined(__linux) && !defined(TRAVIS)
-TEST_F(TitanDBTest, NoSpaceLeft) {
+TEST_F(TitanDBTest, DISABLED_NoSpaceLeft) {
   options_.disable_background_gc = false;
   system(("mkdir -p " + dbname_).c_str());
   system(("sudo mount -t tmpfs -o size=1m tmpfs " + dbname_).c_str());


### PR DESCRIPTION
In our CI environment we need to link pthread to enable sanitizer builds (ASAN, TSAN, UBSAN). Update cmake script for it.

It still needs #218 to get the CI pass.

Also disabling NoSpaceLeft test just like in Travis.

Signed-off-by: Yi Wu <yiwu@pingcap.com>