### PR TITLE
Fix false corruption error when reading from v1 blob file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,10 @@ if (WITH_TITAN_TOOLS)
   add_executable(titan_manifest_dump tools/manifest_dump.cc)
   target_include_directories(titan_manifest_dump PRIVATE ${gflags_INCLUDE_DIR})
   target_link_libraries(titan_manifest_dump ${TOOLS_LIBS})
+  
+  add_executable(titan_blob_file_dump tools/blob_file_dump.cc)
+  target_include_directories(titan_blob_file_dump PRIVATE ${gflags_INCLUDE_DIR})
+  target_link_libraries(titan_blob_file_dump ${TOOLS_LIBS})
 endif()
 
 # Installation - copy lib/ and include/

--- a/src/blob_file_builder.h
+++ b/src/blob_file_builder.h
@@ -67,7 +67,8 @@ class BlobFileBuilder {
   // is building in "*file". Does not close the file. It is up to the
   // caller to sync and close the file after calling Finish().
   BlobFileBuilder(const TitanDBOptions& db_options,
-                  const TitanCFOptions& cf_options, WritableFileWriter* file);
+                  const TitanCFOptions& cf_options, WritableFileWriter* file,
+                  uint32_t blob_file_version = BlobFileHeader::kVersion2);
 
   // Tries to add the record to the file
   // Notice:
@@ -124,6 +125,7 @@ class BlobFileBuilder {
 
   TitanCFOptions cf_options_;
   WritableFileWriter* file_;
+  const uint32_t blob_file_version_;
 
   Status status_;
   BlobEncoder encoder_;

--- a/src/blob_file_iterator.cc
+++ b/src/blob_file_iterator.cc
@@ -28,7 +28,7 @@ bool BlobFileIterator::Init() {
     return false;
   }
   BlobFileHeader blob_file_header;
-  status_ = DecodeInto(slice, &blob_file_header, true/*ignore_extra_bytes*/);
+  status_ = DecodeInto(slice, &blob_file_header, true /*ignore_extra_bytes*/);
   if (!status_.ok()) {
     return false;
   }

--- a/src/blob_file_iterator.cc
+++ b/src/blob_file_iterator.cc
@@ -28,7 +28,7 @@ bool BlobFileIterator::Init() {
     return false;
   }
   BlobFileHeader blob_file_header;
-  status_ = DecodeInto(slice, &blob_file_header);
+  status_ = DecodeInto(slice, &blob_file_header, true/*ignore_extra_bytes*/);
   if (!status_.ok()) {
     return false;
   }

--- a/src/blob_file_iterator.cc
+++ b/src/blob_file_iterator.cc
@@ -28,7 +28,7 @@ bool BlobFileIterator::Init() {
     return false;
   }
   BlobFileHeader blob_file_header;
-  status_ = blob_file_header.DecodeFrom(&slice);
+  status_ = DecodeInto(slice, &blob_file_header);
   if (!status_.ok()) {
     return false;
   }

--- a/src/blob_file_reader.cc
+++ b/src/blob_file_reader.cc
@@ -125,7 +125,7 @@ Status BlobFileReader::ReadHeader(std::unique_ptr<RandomAccessFileReader>& file,
       file->Read(0, BlobFileHeader::kMaxEncodedLength, &buffer, buffer.get());
   if (!s.ok()) return s;
 
-  s = DecodeInto(buffer, header);
+  s = DecodeInto(buffer, header, true /*ignore_extra_bytes*/);
 
   return s;
 }

--- a/tools/blob_file_dump.cc
+++ b/tools/blob_file_dump.cc
@@ -8,8 +8,6 @@ using GFLAGS_NAMESPACE::ParseCommandLineFlags;
 using GFLAGS_NAMESPACE::SetUsageMessage;
 
 DEFINE_string(path, "", "Path of blob file.");
-DEFINE_uint64(size, 0, "blob file size");
-DEFINE_uint64(number, 0, "blob file number");
 DEFINE_bool(dump, false, "");
 
 #define handle_error(s, location)                                           \
@@ -24,29 +22,31 @@ namespace titandb {
 int blob_file_dump() {
   Env* env = Env::Default();
   Status s;
+    
+  std::string file_name = FLAGS_path;
+  uint64_t file_size = 0;
+  s = env->GetFileSize(file_name, &file_size);
+  handle_error(s, "getting file size");
 
   std::unique_ptr<RandomAccessFileReader> file;
   std::unique_ptr<RandomAccessFile> f;
-  std::string file_name = FLAGS_path;
   s = env->NewRandomAccessFile(file_name, &f, EnvOptions());
   handle_error(s, "open file");
   file.reset(new RandomAccessFileReader(std::move(f), file_name));
 
   std::unique_ptr<BlobFileIterator> iter(new BlobFileIterator(
-      std::move(file), FLAGS_number, FLAGS_size, TitanCFOptions()));
+      std::move(file), 1/*fake file number*/, file_size, TitanCFOptions()));
 
-  printf("seek\n");
   iter->SeekToFirst();
   while (iter->Valid()) {
     handle_error(iter->status(), "status");
     if (FLAGS_dump) {
       std::string key = iter->key().ToString(true);
       std::string value = iter->value().ToString(true);
-      printf("%s: %s\n", key.c_str(), value.c_str());
+      fprintf(stdout, "%s: %s\n", key.c_str(), value.c_str());
     }
   }
-
-  handle_error(iter->status(), "reader open");
+  handle_error(iter->status(), "reading blob file");
   return 0;
 }
 

--- a/tools/blob_file_dump.cc
+++ b/tools/blob_file_dump.cc
@@ -22,7 +22,7 @@ namespace titandb {
 int blob_file_dump() {
   Env* env = Env::Default();
   Status s;
-    
+
   std::string file_name = FLAGS_path;
   uint64_t file_size = 0;
   s = env->GetFileSize(file_name, &file_size);
@@ -35,7 +35,7 @@ int blob_file_dump() {
   file.reset(new RandomAccessFileReader(std::move(f), file_name));
 
   std::unique_ptr<BlobFileIterator> iter(new BlobFileIterator(
-      std::move(file), 1/*fake file number*/, file_size, TitanCFOptions()));
+      std::move(file), 1 /*fake file number*/, file_size, TitanCFOptions()));
 
   iter->SeekToFirst();
   while (iter->Valid()) {

--- a/tools/blob_file_dump.cc
+++ b/tools/blob_file_dump.cc
@@ -1,0 +1,61 @@
+// Copyright 2021-present TiKV Project Authors. Licensed under Apache-2.0.
+
+#include "blob_file_iterator.h"
+#include "file/filename.h"
+#include "util/gflags_compat.h"
+
+using GFLAGS_NAMESPACE::ParseCommandLineFlags;
+using GFLAGS_NAMESPACE::SetUsageMessage;
+
+DEFINE_string(path, "", "Path of blob file.");
+DEFINE_uint64(size, 0, "blob file size");
+DEFINE_uint64(number, 0, "blob file number");
+DEFINE_bool(dump, false, "");
+
+#define handle_error(s, location)                                           \
+  if (!s.ok()) {                                                            \
+    fprintf(stderr, "error when %s: %s\n", location, s.ToString().c_str()); \
+    return 1;                                                               \
+  }
+
+namespace rocksdb {
+namespace titandb {
+
+int blob_file_dump() {
+  Env* env = Env::Default();
+  Status s;
+
+  std::unique_ptr<RandomAccessFileReader> file;
+  std::unique_ptr<RandomAccessFile> f;
+  std::string file_name = FLAGS_path;
+  s = env->NewRandomAccessFile(file_name, &f, EnvOptions());
+  handle_error(s, "open file");
+  file.reset(new RandomAccessFileReader(std::move(f), file_name));
+
+  std::unique_ptr<BlobFileIterator> iter(new BlobFileIterator(
+      std::move(file), FLAGS_number, FLAGS_size, TitanCFOptions()));
+
+  printf("seek\n");
+  iter->SeekToFirst();
+  while (iter->Valid()) {
+    handle_error(iter->status(), "status");
+    if (FLAGS_dump) {
+      std::string key = iter->key().ToString(true);
+      std::string value = iter->value().ToString(true);
+      printf("%s: %s\n", key.c_str(), value.c_str());
+    }
+  }
+
+  handle_error(iter->status(), "reader open");
+  return 0;
+}
+
+}  // namespace titandb
+}  // namespace rocksdb
+
+int main(int argc, char** argv) {
+  SetUsageMessage(std::string("\nUSAGE\n") + std::string(argv[0]) +
+                  " [OPTIONS]...");
+  ParseCommandLineFlags(&argc, &argv, true);
+  return rocksdb::titandb::blob_file_dump();
+}


### PR DESCRIPTION
To support dictionary compression we added a v2 blob file header to store extra flags. However, the check in BlobFileReader , when reading a v1 blob file, falsely asserted the file header is shorter than expected:
https://github.com/tikv/titan/blob/ecb5cba016096309cbd9b566bdc4ce62307527a0/src/blob_file_reader.cc#L103
https://github.com/tikv/titan/blob/ecb5cba016096309cbd9b566bdc4ce62307527a0/src/blob_format.h#L394
Refactoring the code to bypass the check to fix the issue.

The issue is introduced in https://github.com/tikv/titan/pull/189. TiKV is affected when Titan is enabled and upgrade from pre-5.0 versions to >=5.0.0 versions. It will make TiKV fall in crash loop.

Also adding a titan_blob_file_dump tool to dump blob file content.