### PR TITLE
Fix false corruption error when reading from v1 blob file (#221)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,10 @@ if (WITH_TITAN_TOOLS)
   add_executable(titan_manifest_dump tools/manifest_dump.cc)
   target_include_directories(titan_manifest_dump PRIVATE ${gflags_INCLUDE_DIR})
   target_link_libraries(titan_manifest_dump ${TOOLS_LIBS})
+  
+  add_executable(titan_blob_file_dump tools/blob_file_dump.cc)
+  target_include_directories(titan_blob_file_dump PRIVATE ${gflags_INCLUDE_DIR})
+  target_link_libraries(titan_blob_file_dump ${TOOLS_LIBS})
 endif()
 
 # Installation - copy lib/ and include/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,7 @@ if (NOT DEFINED ROCKSDB_DIR)
   message(FATAL_ERROR "ROCKSDB_DIR is not defined.")
 endif()
 
-set(CMAKE_MODULE_PATH "${ROCKSDB_DIR}/cmake/modules/")
-# list(APPEND CMAKE_MODULE_PATH "${ROCKSDB_DIR}/cmake/modules/")
+get_filename_component(CMAKE_MODULE_PATH "${ROCKSDB_DIR}/cmake/modules/" ABSOLUTE)
 include(cmake/rocksdb_flags.cmake)
 
 include_directories(${ROCKSDB_DIR})
@@ -78,6 +77,17 @@ if (CODE_COVERAGE)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
 endif()
 
+set(COMMON_LIBS
+  titan
+  rocksdb)
+
+if(WITH_ASAN OR WITH_TSAN)
+  find_package(Threads)
+  if(CMAKE_USE_PTHREADS_INIT)
+    link_libraries(pthread)
+  endif()
+endif()
+
 if (WITH_TITAN_TESTS OR WITH_TITAN_TOOLS)
   add_subdirectory(${ROCKSDB_DIR} rocksdb EXCLUDE_FROM_ALL)
   # -latomic is needed when building titandb_stress using clang.
@@ -108,8 +118,7 @@ if (WITH_TITAN_TESTS AND (NOT CMAKE_BUILD_TYPE STREQUAL "Release"))
         compaction_filter_test
         version_test)
   set(TEST_LIBS
-        titan
-        rocksdb
+        ${COMMON_LIBS}
         testutillib
         gtest)
 
@@ -121,9 +130,7 @@ if (WITH_TITAN_TESTS AND (NOT CMAKE_BUILD_TYPE STREQUAL "Release"))
 endif()
 
 if (WITH_TITAN_TOOLS)
-  set(TOOLS_LIBS
-        titan
-        rocksdb)
+  set(TOOLS_LIBS ${COMMON_LIBS})
 
   if (NOT TRAVIS)
     find_package(gflags REQUIRED)

--- a/src/blob_file_builder.h
+++ b/src/blob_file_builder.h
@@ -67,7 +67,8 @@ class BlobFileBuilder {
   // is building in "*file". Does not close the file. It is up to the
   // caller to sync and close the file after calling Finish().
   BlobFileBuilder(const TitanDBOptions& db_options,
-                  const TitanCFOptions& cf_options, WritableFileWriter* file);
+                  const TitanCFOptions& cf_options, WritableFileWriter* file,
+                  uint32_t blob_file_version = BlobFileHeader::kVersion2);
 
   // Tries to add the record to the file
   // Notice:
@@ -124,6 +125,7 @@ class BlobFileBuilder {
 
   TitanCFOptions cf_options_;
   WritableFileWriter* file_;
+  const uint32_t blob_file_version_;
 
   Status status_;
   BlobEncoder encoder_;

--- a/src/blob_file_iterator.cc
+++ b/src/blob_file_iterator.cc
@@ -28,7 +28,7 @@ bool BlobFileIterator::Init() {
     return false;
   }
   BlobFileHeader blob_file_header;
-  status_ = blob_file_header.DecodeFrom(&slice);
+  status_ = DecodeInto(slice, &blob_file_header, true /*ignore_extra_bytes*/);
   if (!status_.ok()) {
     return false;
   }

--- a/src/blob_file_reader.cc
+++ b/src/blob_file_reader.cc
@@ -125,7 +125,7 @@ Status BlobFileReader::ReadHeader(std::unique_ptr<RandomAccessFileReader>& file,
       file->Read(0, BlobFileHeader::kMaxEncodedLength, &buffer, buffer.get());
   if (!s.ok()) return s;
 
-  s = DecodeInto(buffer, header);
+  s = DecodeInto(buffer, header, true /*ignore_extra_bytes*/);
 
   return s;
 }

--- a/src/blob_file_set.cc
+++ b/src/blob_file_set.cc
@@ -3,6 +3,7 @@
 #include <inttypes.h>
 
 #include "edit_collector.h"
+#include "titan_logging.h"
 
 namespace rocksdb {
 namespace titandb {
@@ -83,7 +84,7 @@ Status BlobFileSet::Recover() {
     s = collector.GetNextFileNumber(&next_file_number);
     if (!s.ok()) return s;
     next_file_number_.store(next_file_number);
-    ROCKS_LOG_INFO(db_options_.info_log,
+    TITAN_LOG_INFO(db_options_.info_log,
                    "Next blob file number is %" PRIu64 ".", next_file_number);
   }
 
@@ -105,7 +106,7 @@ Status BlobFileSet::Recover() {
         files_str.append("(obsolete)");
       }
     }
-    ROCKS_LOG_INFO(db_options_.info_log,
+    TITAN_LOG_INFO(db_options_.info_log,
                    "Blob files for CF %" PRIu32 " found: %s", bs.first,
                    files_str.c_str());
     // delete obsoleted files at reopen
@@ -125,7 +126,7 @@ Status BlobFileSet::Recover() {
     if (file_type != FileType::kBlobFile &&
         file_type != FileType::kDescriptorFile)
       continue;
-    ROCKS_LOG_INFO(db_options_.info_log,
+    TITAN_LOG_INFO(db_options_.info_log,
                    "Titan recovery delete obsolete file %s.", f.c_str());
     env_->DeleteFile(dirname_ + "/" + f);
   }
@@ -241,7 +242,7 @@ Status BlobFileSet::DropColumnFamilies(
       edit.SetColumnFamilyID(it->first);
       for (auto& file : it->second->files_) {
         if (!file.second->is_obsolete()) {
-          ROCKS_LOG_INFO(db_options_.info_log,
+          TITAN_LOG_INFO(db_options_.info_log,
                          "Titan add obsolete file [%" PRIu64 "]",
                          file.second->file_number());
           edit.DeleteBlobFile(file.first, obsolete_sequence);
@@ -250,7 +251,7 @@ Status BlobFileSet::DropColumnFamilies(
       s = LogAndApply(edit);
       if (!s.ok()) return s;
     } else {
-      ROCKS_LOG_ERROR(db_options_.info_log, "column %u not found for drop\n",
+      TITAN_LOG_ERROR(db_options_.info_log, "column %u not found for drop\n",
                       cf_id);
       return Status::NotFound("invalid column family");
     }
@@ -269,7 +270,7 @@ Status BlobFileSet::MaybeDestroyColumnFamily(uint32_t cf_id) {
     }
     return Status::OK();
   }
-  ROCKS_LOG_ERROR(db_options_.info_log, "column %u not found for destroy\n",
+  TITAN_LOG_ERROR(db_options_.info_log, "column %u not found for destroy\n",
                   cf_id);
   return Status::NotFound("invalid column family");
 }
@@ -292,7 +293,7 @@ Status BlobFileSet::DeleteBlobFilesInRanges(uint32_t cf_id,
     s = LogAndApply(edit);
     return s;
   }
-  ROCKS_LOG_ERROR(db_options_.info_log,
+  TITAN_LOG_ERROR(db_options_.info_log,
                   "column %u not found for delete blob files in ranges\n",
                   cf_id);
   return Status::NotFound("invalid column family");

--- a/src/blob_gc_job.cc
+++ b/src/blob_gc_job.cc
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "blob_file_size_collector.h"
+#include "titan_logging.h"
 
 namespace rocksdb {
 namespace titandb {
@@ -133,7 +134,7 @@ Status BlobGCJob::Run() {
     }
     tmp.append(std::to_string(f->file_number()));
   }
-  ROCKS_LOG_BUFFER(log_buffer_, "[%s] Titan GC candidates[%s]",
+  TITAN_LOG_BUFFER(log_buffer_, "[%s] Titan GC candidates[%s]",
                    blob_gc_->column_family_handle()->GetName().c_str(),
                    tmp.c_str());
   return DoRunGC();
@@ -214,7 +215,7 @@ Status BlobGCJob::DoRunGC() {
       if (!s.ok()) {
         break;
       }
-      ROCKS_LOG_INFO(db_options_.info_log,
+      TITAN_LOG_INFO(db_options_.info_log,
                      "Titan new GC output file %" PRIu64 ".",
                      blob_file_handle->GetNumber());
       blob_file_builder = std::unique_ptr<BlobFileBuilder>(
@@ -378,13 +379,13 @@ Status BlobGCJob::Finish() {
       TEST_SYNC_POINT("BlobGCJob::Finish::BeforeRewriteValidKeyToLSM");
       s = RewriteValidKeyToLSM();
       if (!s.ok()) {
-        ROCKS_LOG_ERROR(db_options_.info_log,
+        TITAN_LOG_ERROR(db_options_.info_log,
                         "[%s] GC job failed to rewrite keys to LSM: %s",
                         blob_gc_->column_family_handle()->GetName().c_str(),
                         s.ToString().c_str());
       }
     } else {
-      ROCKS_LOG_ERROR(db_options_.info_log,
+      TITAN_LOG_ERROR(db_options_.info_log,
                       "[%s] GC job failed to install output blob files: %s",
                       blob_gc_->column_family_handle()->GetName().c_str(),
                       s.ToString().c_str());
@@ -433,7 +434,7 @@ Status BlobGCJob::InstallOutputBlobFiles() {
     files.emplace_back(std::make_pair(file, std::move(builder.first)));
   }
   if (s.ok()) {
-    ROCKS_LOG_BUFFER(log_buffer_, "[%s] output[%s]",
+    TITAN_LOG_BUFFER(log_buffer_, "[%s] output[%s]",
                      blob_gc_->column_family_handle()->GetName().c_str(),
                      tmp.c_str());
     s = blob_file_manager_->BatchFinishFiles(
@@ -453,7 +454,7 @@ Status BlobGCJob::InstallOutputBlobFiles() {
       to_delete_files.append(std::to_string(builder.first->GetNumber()));
       handles.emplace_back(std::move(builder.first));
     }
-    ROCKS_LOG_BUFFER(log_buffer_,
+    TITAN_LOG_BUFFER(log_buffer_,
                      "[%s] InstallOutputBlobFiles failed. Delete GC output "
                      "files: %s",
                      blob_gc_->column_family_handle()->GetName().c_str(),
@@ -463,7 +464,7 @@ Status BlobGCJob::InstallOutputBlobFiles() {
     // LSM by mistake.
     Status status = blob_file_manager_->BatchDeleteFiles(handles);
     if (!status.ok()) {
-      ROCKS_LOG_WARN(db_options_.info_log,
+      TITAN_LOG_WARN(db_options_.info_log,
                      "Delete GC output files[%s] failed: %s",
                      to_delete_files.c_str(), status.ToString().c_str());
     }
@@ -554,7 +555,7 @@ Status BlobGCJob::RewriteValidKeyToLSM() {
     if (blob_storage) {
       auto file = blob_storage->FindFile(blob_file.first).lock();
       if (!file) {
-        ROCKS_LOG_ERROR(db_options_.info_log,
+        TITAN_LOG_ERROR(db_options_.info_log,
                         "Blob File %" PRIu64 " not found when GC.",
                         blob_file.first);
         continue;
@@ -565,7 +566,7 @@ Status BlobGCJob::RewriteValidKeyToLSM() {
 
       blob_storage->ComputeGCScore();
     } else {
-      ROCKS_LOG_ERROR(db_options_.info_log,
+      TITAN_LOG_ERROR(db_options_.info_log,
                       "Column family id:%" PRIu32 " not Found when GC.", cf_id);
     }
   }
@@ -586,7 +587,7 @@ Status BlobGCJob::DeleteInputBlobFiles() {
   VersionEdit edit;
   edit.SetColumnFamilyID(blob_gc_->column_family_handle()->GetID());
   for (const auto& file : blob_gc_->inputs()) {
-    ROCKS_LOG_INFO(db_options_.info_log,
+    TITAN_LOG_INFO(db_options_.info_log,
                    "Titan add obsolete file [%" PRIu64 "] range [%s, %s]",
                    file->file_number(),
                    Slice(file->smallest_key()).ToString(true).c_str(),

--- a/src/blob_gc_picker.cc
+++ b/src/blob_gc_picker.cc
@@ -6,6 +6,8 @@
 
 #include <inttypes.h>
 
+#include "titan_logging.h"
+
 namespace rocksdb {
 namespace titandb {
 
@@ -34,7 +36,7 @@ std::unique_ptr<BlobGC> BasicBlobGCPicker::PickBlobGC(
     if (!CheckBlobFile(blob_file.get())) {
       // Skip this file id this file is being GCed
       // or this file had been GCed
-      ROCKS_LOG_INFO(db_options_.info_log, "Blob file %" PRIu64 " no need gc",
+      TITAN_LOG_INFO(db_options_.info_log, "Blob file %" PRIu64 " no need gc",
                      blob_file->file_number());
       continue;
     }
@@ -53,7 +55,7 @@ std::unique_ptr<BlobGC> BasicBlobGCPicker::PickBlobGC(
       if (next_gc_size > cf_options_.min_gc_batch_size) {
         maybe_continue_next_time = true;
         RecordTick(statistics(stats_), TITAN_GC_REMAIN, 1);
-        ROCKS_LOG_INFO(db_options_.info_log,
+        TITAN_LOG_INFO(db_options_.info_log,
                        "remain more than %" PRIu64
                        " bytes to be gc and trigger after this gc",
                        next_gc_size);
@@ -61,7 +63,7 @@ std::unique_ptr<BlobGC> BasicBlobGCPicker::PickBlobGC(
       }
     }
   }
-  ROCKS_LOG_DEBUG(db_options_.info_log,
+  TITAN_LOG_DEBUG(db_options_.info_log,
                   "got batch size %" PRIu64 ", estimate output %" PRIu64
                   " bytes",
                   batch_size, estimate_output_size);

--- a/src/blob_storage.cc
+++ b/src/blob_storage.cc
@@ -1,5 +1,7 @@
 #include "blob_storage.h"
+
 #include "blob_file_set.h"
+#include "titan_logging.h"
 
 namespace rocksdb {
 namespace titandb {
@@ -58,7 +60,7 @@ Status BlobStorage::GetBlobFilesInRanges(const RangePtr* ranges, size_t n,
       assert(it->second->smallest_key().empty() ||
              (!begin || cmp->Compare(it->second->smallest_key(), *begin) >= 0));
     }
-    ROCKS_LOG_INFO(
+    TITAN_LOG_INFO(
         db_options_.info_log,
         "Get %" PRIuPTR " blob files [%s] in the range [%s, %s%c",
         files->size(), tmp.c_str(), begin ? begin->ToString(true).c_str() : " ",
@@ -171,7 +173,7 @@ void BlobStorage::GetObsoleteFiles(std::vector<std::string>* obsolete_files,
       // remove obsolete files
       bool __attribute__((__unused__)) removed = RemoveFile(file_number);
       assert(removed);
-      ROCKS_LOG_INFO(db_options_.info_log,
+      TITAN_LOG_INFO(db_options_.info_log,
                      "Obsolete blob file %" PRIu64 " (obsolete at %" PRIu64
                      ") not visible to oldest snapshot %" PRIu64 ", delete it.",
                      file_number, obsolete_sequence, oldest_sequence);

--- a/src/compaction_filter.h
+++ b/src/compaction_filter.h
@@ -5,6 +5,7 @@
 
 #include "db_impl.h"
 #include "rocksdb/compaction_filter.h"
+#include "titan_logging.h"
 #include "util/mutexlock.h"
 
 namespace rocksdb {
@@ -48,7 +49,7 @@ class TitanCompactionFilter final : public CompactionFilter {
     Slice original_value(value.data());
     Status s = blob_index.DecodeFrom(&original_value);
     if (!s.ok()) {
-      ROCKS_LOG_ERROR(db_->db_options_.info_log,
+      TITAN_LOG_ERROR(db_->db_options_.info_log,
                       "[%s] Unable to decode blob index", cf_name_.c_str());
       // TODO(yiwu): Better to fail the compaction as well, but current
       // compaction filter API doesn't support it.

--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -18,6 +18,7 @@
 #include "port/port.h"
 #include "table_factory.h"
 #include "titan_build_version.h"
+#include "titan_logging.h"
 #include "titan_stats.h"
 #include "util/autovector.h"
 #include "util/threadpool_imp.h"
@@ -70,7 +71,7 @@ class TitanDBImpl::FileManager : public BlobFileManager {
       }
       if (!s.ok()) return s;
 
-      ROCKS_LOG_INFO(db_->db_options_.info_log,
+      TITAN_LOG_INFO(db_->db_options_.info_log,
                      "Titan adding blob file [%" PRIu64 "] range [%s, %s]",
                      file.first->file_number(),
                      Slice(file.first->smallest_key()).ToString(true).c_str(),
@@ -195,7 +196,7 @@ Status TitanDBImpl::Open(const std::vector<TitanCFDescriptor>& descs,
       for (ColumnFamilyHandle* cfh : *handles) {
         Status destroy_handle_status = db_->DestroyColumnFamilyHandle(cfh);
         if (!destroy_handle_status.ok()) {
-          ROCKS_LOG_ERROR(db_options_.info_log,
+          TITAN_LOG_ERROR(db_options_.info_log,
                           "Failed to destroy CF handle after open failure: %s",
                           destroy_handle_status.ToString().c_str());
         }
@@ -205,7 +206,7 @@ Status TitanDBImpl::Open(const std::vector<TitanCFDescriptor>& descs,
     if (db_ != nullptr) {
       Status close_status = db_->Close();
       if (!close_status.ok()) {
-        ROCKS_LOG_ERROR(db_options_.info_log,
+        TITAN_LOG_ERROR(db_options_.info_log,
                         "Failed to close base DB after open failure: %s",
                         close_status.ToString().c_str());
       }
@@ -329,12 +330,12 @@ Status TitanDBImpl::OpenImpl(const std::vector<TitanCFDescriptor>& descs,
   }
   StartBackgroundTasks();
   // Dump options.
-  ROCKS_LOG_INFO(db_options_.info_log, "Titan DB open.");
-  ROCKS_LOG_HEADER(db_options_.info_log, "Titan git sha: %s",
+  TITAN_LOG_INFO(db_options_.info_log, "Titan DB open.");
+  TITAN_LOG_HEADER(db_options_.info_log, "Titan git sha: %s",
                    titan_build_git_sha);
   db_options_.Dump(db_options_.info_log.get());
   for (auto& desc : descs) {
-    ROCKS_LOG_HEADER(db_options_.info_log,
+    TITAN_LOG_HEADER(db_options_.info_log,
                      "Column family [%s], options:", desc.name.c_str());
     desc.options.Dump(db_options_.info_log.get());
   }
@@ -445,7 +446,7 @@ Status TitanDBImpl::CreateColumnFamilies(
   }
   if (s.ok()) {
     for (auto& desc : descs) {
-      ROCKS_LOG_INFO(db_options_.info_log, "Created column family [%s].",
+      TITAN_LOG_INFO(db_options_.info_log, "Created column family [%s].",
                      desc.name.c_str());
       desc.options.Dump(db_options_.info_log.get());
     }
@@ -454,7 +455,7 @@ Status TitanDBImpl::CreateColumnFamilies(
     for (auto& desc : descs) {
       column_families_str += "[" + desc.name + "]";
     }
-    ROCKS_LOG_ERROR(db_options_.info_log,
+    TITAN_LOG_ERROR(db_options_.info_log,
                     "Failed to create column families %s: %s",
                     column_families_str.c_str(), s.ToString().c_str());
   }
@@ -494,10 +495,10 @@ Status TitanDBImpl::DropColumnFamilies(
     }
   }
   if (s.ok()) {
-    ROCKS_LOG_INFO(db_options_.info_log, "Dropped column families: %s",
+    TITAN_LOG_INFO(db_options_.info_log, "Dropped column families: %s",
                    column_families_str.c_str());
   } else {
-    ROCKS_LOG_ERROR(db_options_.info_log,
+    TITAN_LOG_ERROR(db_options_.info_log,
                     "Failed to drop column families %s: %s",
                     column_families_str.c_str(), s.ToString().c_str());
   }
@@ -524,10 +525,10 @@ Status TitanDBImpl::DestroyColumnFamilyHandle(
     }
   }
   if (s.ok()) {
-    ROCKS_LOG_INFO(db_options_.info_log, "Destroyed column family handle [%s].",
+    TITAN_LOG_INFO(db_options_.info_log, "Destroyed column family handle [%s].",
                    cf_name.c_str());
   } else {
-    ROCKS_LOG_ERROR(db_options_.info_log,
+    TITAN_LOG_ERROR(db_options_.info_log,
                     "Failed to destroy column family handle [%s]: %s",
                     cf_name.c_str(), s.ToString().c_str());
   }
@@ -648,13 +649,13 @@ Status TitanDBImpl::GetImpl(const ReadOptions& options,
     RecordTick(statistics(stats_.get()), TITAN_BLOB_FILE_BYTES_READ,
                index.blob_handle.size);
   } else {
-    ROCKS_LOG_ERROR(db_options_.info_log,
+    TITAN_LOG_ERROR(db_options_.info_log,
                     "Column family id:%" PRIu32 " not Found.", handle->GetID());
     return Status::NotFound(
         "Column family id: " + std::to_string(handle->GetID()) + " not Found.");
   }
   if (s.IsCorruption()) {
-    ROCKS_LOG_ERROR(db_options_.info_log,
+    TITAN_LOG_ERROR(db_options_.info_log,
                     "Key:%s Snapshot:%" PRIu64 " GetBlobFile err:%s\n",
                     key.ToString(true).c_str(),
                     options.snapshot->GetSequenceNumber(),
@@ -722,7 +723,7 @@ Iterator* TitanDBImpl::NewIteratorImpl(
   mutex_.Unlock();
 
   if (!storage) {
-    ROCKS_LOG_ERROR(db_options_.info_log,
+    TITAN_LOG_ERROR(db_options_.info_log,
                     "Column family id:%" PRIu32 " not Found.", handle->GetID());
     return nullptr;
   }
@@ -845,7 +846,7 @@ Status TitanDBImpl::DeleteFilesInRanges(ColumnFamilyHandle* column_family,
         prop.second, false /*to_add*/, &blob_file_size_diff);
     if (!gc_stats_status.ok()) {
       // TODO: Should treat it as background error and make DB read-only.
-      ROCKS_LOG_ERROR(db_options_.info_log,
+      TITAN_LOG_ERROR(db_options_.info_log,
                       "failed to extract GC stats, file: %s, error: %s",
                       prop.first.c_str(), gc_stats_status.ToString().c_str());
       assert(false);
@@ -865,7 +866,7 @@ Status TitanDBImpl::DeleteFilesInRanges(ColumnFamilyHandle* column_family,
   auto bs = blob_file_set_->GetBlobStorage(cf_id).lock();
   if (!bs) {
     // TODO: Should treat it as background error and make DB read-only.
-    ROCKS_LOG_ERROR(db_options_.info_log,
+    TITAN_LOG_ERROR(db_options_.info_log,
                     "Column family id:%" PRIu32 " not Found.", cf_id);
     return Status::NotFound("Column family id: " + std::to_string(cf_id) +
                             " not Found.");
@@ -885,7 +886,7 @@ Status TitanDBImpl::DeleteFilesInRanges(ColumnFamilyHandle* column_family,
       auto before = file->GetDiscardableRatioLevel();
       bool ok = file->UpdateLiveDataSize(delta);
       if (!ok) {
-        ROCKS_LOG_WARN(db_options_.info_log,
+        TITAN_LOG_WARN(db_options_.info_log,
                        "During DeleteFilesInRanges: blob file %" PRIu64
                        " live size below zero.",
                        file_number);
@@ -978,7 +979,7 @@ Options TitanDBImpl::GetOptions(ColumnFamilyHandle* column_family) const {
   if (cf_info_.count(cf_id) > 0) {
     options.table_factory = cf_info_.at(cf_id).base_table_factory;
   } else {
-    ROCKS_LOG_ERROR(
+    TITAN_LOG_ERROR(
         db_options_.info_log,
         "Failed to get original table factory for column family %s.",
         column_family->GetName().c_str());
@@ -1007,7 +1008,7 @@ Status TitanDBImpl::SetOptions(
                                        blob_run_mode_string);
       } else {
         blob_run_mode = pm->second;
-        ROCKS_LOG_INFO(db_options_.info_log, "[%s] Set blob_run_mode: %s",
+        TITAN_LOG_INFO(db_options_.info_log, "[%s] Set blob_run_mode: %s",
                        column_family->GetName().c_str(),
                        blob_run_mode_string.c_str());
       }
@@ -1125,7 +1126,7 @@ void TitanDBImpl::OnFlushCompleted(const FlushJobInfo& flush_job_info) {
       flush_job_info.table_properties, true /*to_add*/, &blob_file_size_diff);
   if (!s.ok()) {
     // TODO: Should treat it as background error and make DB read-only.
-    ROCKS_LOG_ERROR(db_options_.info_log,
+    TITAN_LOG_ERROR(db_options_.info_log,
                     "OnFlushCompleted[%d]: failed to extract GC stats: %s",
                     flush_job_info.job_id, s.ToString().c_str());
     assert(false);
@@ -1137,7 +1138,7 @@ void TitanDBImpl::OnFlushCompleted(const FlushJobInfo& flush_job_info) {
         blob_file_set_->GetBlobStorage(flush_job_info.cf_id).lock();
     if (!blob_storage) {
       // TODO: Should treat it as background error and make DB read-only.
-      ROCKS_LOG_ERROR(db_options_.info_log,
+      TITAN_LOG_ERROR(db_options_.info_log,
                       "OnFlushCompleted[%d]: Column family id: %" PRIu32
                       " Not Found.",
                       flush_job_info.job_id, flush_job_info.cf_id);
@@ -1154,7 +1155,7 @@ void TitanDBImpl::OnFlushCompleted(const FlushJobInfo& flush_job_info) {
       }
       if (file->file_state() != BlobFileMeta::FileState::kPendingLSM) {
         // This file may be output of a GC job.
-        ROCKS_LOG_INFO(db_options_.info_log,
+        TITAN_LOG_INFO(db_options_.info_log,
                        "OnFlushCompleted[%d]: ignore GC output file %" PRIu64
                        ".",
                        flush_job_info.job_id, file->file_number());
@@ -1162,7 +1163,7 @@ void TitanDBImpl::OnFlushCompleted(const FlushJobInfo& flush_job_info) {
       }
       if (delta < 0) {
         // Cannot happen..
-        ROCKS_LOG_WARN(db_options_.info_log,
+        TITAN_LOG_WARN(db_options_.info_log,
                        "OnFlushCompleted[%d]: New blob file %" PRIu64
                        " live size being negative",
                        flush_job_info.job_id, file_number);
@@ -1186,7 +1187,7 @@ void TitanDBImpl::OnFlushCompleted(const FlushJobInfo& flush_job_info) {
       AddStats(stats_.get(), flush_job_info.cf_id,
                file->GetDiscardableRatioLevel(), 1);
       file->FileStateTransit(BlobFileMeta::FileEvent::kFlushCompleted);
-      ROCKS_LOG_INFO(db_options_.info_log,
+      TITAN_LOG_INFO(db_options_.info_log,
                      "OnFlushCompleted[%d]: output blob file %" PRIu64
                      ","
                      " live data size %" PRIu64 ".",
@@ -1215,7 +1216,7 @@ void TitanDBImpl::OnCompactionCompleted(
     for (const auto& file_name : files) {
       auto prop_iter = prop_collection.find(file_name);
       if (prop_iter == prop_collection.end()) {
-        ROCKS_LOG_WARN(
+        TITAN_LOG_WARN(
             db_options_.info_log,
             "OnCompactionCompleted[%d]: No table properties for file %s.",
             compaction_job_info.job_id, file_name.c_str());
@@ -1225,7 +1226,7 @@ void TitanDBImpl::OnCompactionCompleted(
           prop_iter->second, to_add, &blob_file_size_diff);
       if (!gc_stats_status.ok()) {
         // TODO: Should treat it as background error and make DB read-only.
-        ROCKS_LOG_ERROR(
+        TITAN_LOG_ERROR(
             db_options_.info_log,
             "OnCompactionCompleted[%d]: failed to extract GC stats from table "
             "property: compaction file: %s, error: %s",
@@ -1243,7 +1244,7 @@ void TitanDBImpl::OnCompactionCompleted(
     auto bs = blob_file_set_->GetBlobStorage(compaction_job_info.cf_id).lock();
     if (!bs) {
       // TODO: Should treat it as background error and make DB read-only.
-      ROCKS_LOG_ERROR(db_options_.info_log,
+      TITAN_LOG_ERROR(db_options_.info_log,
                       "OnCompactionCompleted[%d] Column family id:%" PRIu32
                       " not Found.",
                       compaction_job_info.job_id, compaction_job_info.cf_id);
@@ -1281,14 +1282,14 @@ void TitanDBImpl::OnCompactionCompleted(
           bool ok = file->UpdateLiveDataSize(static_cast<uint64_t>(-delta));
           if (!ok) {
             // Cannot happen
-            ROCKS_LOG_WARN(
+            TITAN_LOG_WARN(
                 db_options_.info_log,
                 "OnCompactionCompleted[%d]: pendingLSM Blob file %" PRIu64
                 " live size below zero.",
                 compaction_job_info.job_id, file_number);
             assert(false);
           }
-          ROCKS_LOG_INFO(db_options_.info_log,
+          TITAN_LOG_INFO(db_options_.info_log,
                          "OnCompactionCompleted[%d]: Get blob file %" PRIu64
                          " live size being negative, maybe due to "
                          "OnFlushCompleted() is called yet",
@@ -1307,7 +1308,7 @@ void TitanDBImpl::OnCompactionCompleted(
                  file->GetDiscardableRatioLevel(), 1);
         file->FileStateTransit(BlobFileMeta::FileEvent::kCompactionCompleted);
         to_merge_candidates.push_back(file);
-        ROCKS_LOG_INFO(
+        TITAN_LOG_INFO(
             db_options_.info_log,
             "OnCompactionCompleted[%d]: compaction output blob file %" PRIu64
             ", live data size %" PRIu64 ".",
@@ -1317,7 +1318,7 @@ void TitanDBImpl::OnCompactionCompleted(
                  file->file_state() == BlobFileMeta::FileState::kToMerge) {
         if (delta > 0) {
           assert(false);
-          ROCKS_LOG_WARN(db_options_.info_log,
+          TITAN_LOG_WARN(db_options_.info_log,
                          "OnCompactionCompleted[%d]: Blob file %" PRIu64
                          " live size increase after compaction.",
                          compaction_job_info.job_id, file_number);
@@ -1326,7 +1327,7 @@ void TitanDBImpl::OnCompactionCompleted(
         SubStats(stats_.get(), compaction_job_info.cf_id, before, 1);
         bool ok = file->UpdateLiveDataSize(delta);
         if (!ok) {
-          ROCKS_LOG_WARN(db_options_.info_log,
+          TITAN_LOG_WARN(db_options_.info_log,
                          "OnCompactionCompleted[%d]: Blob file %" PRIu64
                          " live size below zero.",
                          compaction_job_info.job_id, file_number);
@@ -1402,7 +1403,7 @@ void TitanDBImpl::DumpStats() {
     for (auto& cf : cf_info_) {
       TitanInternalStats* internal_stats = stats_->internal_stats(cf.first);
       if (internal_stats == nullptr) {
-        ROCKS_LOG_WARN(db_options_.info_log,
+        TITAN_LOG_WARN(db_options_.info_log,
                        "Column family [%s] missing internal stats.",
                        cf.second.name.c_str());
         continue;

--- a/src/db_impl_files.cc
+++ b/src/db_impl_files.cc
@@ -1,4 +1,5 @@
 #include "db_impl.h"
+#include "titan_logging.h"
 
 namespace rocksdb {
 namespace titandb {
@@ -20,12 +21,12 @@ Status TitanDBImpl::PurgeObsoleteFilesImpl() {
       candidate_files.end());
 
   for (const auto& candidate_file : candidate_files) {
-    ROCKS_LOG_INFO(db_options_.info_log, "Titan deleting obsolete file [%s]",
+    TITAN_LOG_INFO(db_options_.info_log, "Titan deleting obsolete file [%s]",
                    candidate_file.c_str());
     Status delete_status = env_->DeleteFile(candidate_file);
     if (!s.ok()) {
       // Move on despite error deleting the file.
-      ROCKS_LOG_ERROR(db_options_.info_log,
+      TITAN_LOG_ERROR(db_options_.info_log,
                       "Titan deleting file [%s] failed, status:%s",
                       candidate_file.c_str(), s.ToString().c_str());
       s = delete_status;

--- a/src/db_impl_gc.cc
+++ b/src/db_impl_gc.cc
@@ -1,11 +1,10 @@
-#include "db_impl.h"
-
-#include "test_util/sync_point.h"
-
 #include "blob_file_iterator.h"
 #include "blob_file_size_collector.h"
 #include "blob_gc_job.h"
 #include "blob_gc_picker.h"
+#include "db_impl.h"
+#include "test_util/sync_point.h"
+#include "titan_logging.h"
 #include "util.h"
 
 namespace rocksdb {
@@ -175,7 +174,7 @@ Status TitanDBImpl::BackgroundGC(LogBuffer* log_buffer,
     blob_storage = blob_file_set_->GetBlobStorage(column_family_id).lock();
   } else {
     TEST_SYNC_POINT_CALLBACK("TitanDBImpl::BackgroundGC:CFDropped", nullptr);
-    ROCKS_LOG_BUFFER(log_buffer, "GC skip dropped colum family [%s].",
+    TITAN_LOG_BUFFER(log_buffer, "GC skip dropped colum family [%s].",
                      cf_info_[column_family_id].name.c_str());
   }
   if (blob_storage != nullptr) {
@@ -199,7 +198,7 @@ Status TitanDBImpl::BackgroundGC(LogBuffer* log_buffer,
   if (UNLIKELY(!blob_gc)) {
     RecordTick(statistics(stats_.get()), TITAN_GC_NO_NEED, 1);
     // Nothing to do
-    ROCKS_LOG_BUFFER(log_buffer, "Titan GC nothing to do");
+    TITAN_LOG_BUFFER(log_buffer, "Titan GC nothing to do");
   } else {
     StopWatch gc_sw(env_, statistics(stats_.get()), TITAN_GC_MICROS);
     BlobGCJob blob_gc_job(blob_gc.get(), db_, &mutex_, db_options_,
@@ -236,7 +235,7 @@ Status TitanDBImpl::BackgroundGC(LogBuffer* log_buffer,
   } else {
     SetBGError(s);
     RecordTick(statistics(stats_.get()), TITAN_GC_FAILURE, 1);
-    ROCKS_LOG_WARN(db_options_.info_log, "Titan GC error: %s",
+    TITAN_LOG_WARN(db_options_.info_log, "Titan GC error: %s",
                    s.ToString().c_str());
   }
 

--- a/src/db_iter.h
+++ b/src/db_iter.h
@@ -10,9 +10,8 @@
 #include <unordered_map>
 
 #include "db/db_iter.h"
-#include "logging/logging.h"
 #include "rocksdb/env.h"
-
+#include "titan_logging.h"
 #include "titan_stats.h"
 
 namespace rocksdb {
@@ -135,7 +134,7 @@ class TitanDBIterator : public Iterator {
     BlobIndex index;
     status_ = DecodeInto(iter_->value(), &index);
     if (!status_.ok()) {
-      ROCKS_LOG_ERROR(info_log_,
+      TITAN_LOG_ERROR(info_log_,
                       "Titan iterator: failed to decode blob index %s: %s",
                       iter_->value().ToString(true /*hex*/).c_str(),
                       status_.ToString().c_str());
@@ -153,7 +152,7 @@ class TitanDBIterator : public Iterator {
       } else {
         status_ = DecodeInto(iter_->value(), &index);
         if (!status_.ok()) {
-          ROCKS_LOG_ERROR(info_log_,
+          TITAN_LOG_ERROR(info_log_,
                           "Titan iterator: failed to decode blob index %s: %s",
                           iter_->value().ToString(true /*hex*/).c_str(),
                           status_.ToString().c_str());
@@ -170,7 +169,7 @@ class TitanDBIterator : public Iterator {
       std::unique_ptr<BlobFilePrefetcher> prefetcher;
       status_ = storage_->NewPrefetcher(index.file_number, &prefetcher);
       if (!status_.ok()) {
-        ROCKS_LOG_ERROR(
+        TITAN_LOG_ERROR(
             info_log_,
             "Titan iterator: failed to create prefetcher for blob file %" PRIu64
             ": %s",
@@ -183,7 +182,7 @@ class TitanDBIterator : public Iterator {
     buffer_.Reset();
     status_ = it->second->Get(options_, index.blob_handle, &record_, &buffer_);
     if (!status_.ok()) {
-      ROCKS_LOG_ERROR(
+      TITAN_LOG_ERROR(
           info_log_,
           "Titan iterator: failed to read blob value from file %" PRIu64
           ", offset %" PRIu64 ", size %" PRIu64 ": %s\n",

--- a/src/edit_collector.h
+++ b/src/edit_collector.h
@@ -6,6 +6,7 @@
 #include <unordered_map>
 
 #include "blob_file_set.h"
+#include "titan_logging.h"
 #include "util/string_util.h"
 #include "version_edit.h"
 
@@ -144,13 +145,13 @@ class EditCollector {
         auto blob = storage->FindFile(number).lock();
         if (blob) {
           if (blob->is_obsolete()) {
-            ROCKS_LOG_ERROR(storage->db_options().info_log,
+            TITAN_LOG_ERROR(storage->db_options().info_log,
                             "blob file %" PRIu64 " has been deleted before\n",
                             number);
             return Status::Corruption("Blob file " + ToString(number) +
                                       " has been deleted before");
           } else {
-            ROCKS_LOG_ERROR(storage->db_options().info_log,
+            TITAN_LOG_ERROR(storage->db_options().info_log,
                             "blob file %" PRIu64 " has been added before\n",
                             number);
             return Status::Corruption("Blob file " + ToString(number) +
@@ -166,13 +167,13 @@ class EditCollector {
         }
         auto blob = storage->FindFile(number).lock();
         if (!blob) {
-          ROCKS_LOG_ERROR(storage->db_options().info_log,
+          TITAN_LOG_ERROR(storage->db_options().info_log,
                           "blob file %" PRIu64 " doesn't exist before\n",
                           number);
           return Status::Corruption("Blob file " + ToString(number) +
                                     " doesn't exist before");
         } else if (blob->is_obsolete()) {
-          ROCKS_LOG_ERROR(storage->db_options().info_log,
+          TITAN_LOG_ERROR(storage->db_options().info_log,
                           "blob file %" PRIu64 " has been deleted already\n",
                           number);
           return Status::Corruption("Blob file " + ToString(number) +

--- a/src/options.cc
+++ b/src/options.cc
@@ -6,25 +6,25 @@
 
 #include <inttypes.h>
 
-#include "logging/logging.h"
 #include "options/options_helper.h"
 #include "rocksdb/convenience.h"
+#include "titan_logging.h"
 
 namespace rocksdb {
 namespace titandb {
 
 void TitanDBOptions::Dump(Logger* logger) const {
-  ROCKS_LOG_HEADER(logger, "TitanDBOptions.dirname                    : %s",
+  TITAN_LOG_HEADER(logger, "TitanDBOptions.dirname                    : %s",
                    dirname.c_str());
-  ROCKS_LOG_HEADER(logger, "TitanDBOptions.disable_background_gc      : %d",
+  TITAN_LOG_HEADER(logger, "TitanDBOptions.disable_background_gc      : %d",
                    static_cast<int>(disable_background_gc));
-  ROCKS_LOG_HEADER(logger,
+  TITAN_LOG_HEADER(logger,
                    "TitanDBOptions.max_background_gc          : %" PRIi32,
                    max_background_gc);
-  ROCKS_LOG_HEADER(logger,
+  TITAN_LOG_HEADER(logger,
                    "TitanDBOptions.purge_obsolete_files_period_sec: %" PRIu32,
                    purge_obsolete_files_period_sec);
-  ROCKS_LOG_HEADER(logger,
+  TITAN_LOG_HEADER(logger,
                    "TitanDBOptions.titan_stats_dump_period_sec: %" PRIu32,
                    titan_stats_dump_period_sec);
 }
@@ -48,7 +48,7 @@ TitanCFOptions::TitanCFOptions(const ColumnFamilyOptions& cf_opts,
           immutable_opts.skip_value_in_compaction_filter) {}
 
 void TitanCFOptions::Dump(Logger* logger) const {
-  ROCKS_LOG_HEADER(logger,
+  TITAN_LOG_HEADER(logger,
                    "TitanCFOptions.min_blob_size                : %" PRIu64,
                    min_blob_size);
   std::string compression_str = "unknown";
@@ -58,45 +58,45 @@ void TitanCFOptions::Dump(Logger* logger) const {
       break;
     }
   }
-  ROCKS_LOG_HEADER(logger, "TitanCFOptions.blob_file_compression        : %s",
+  TITAN_LOG_HEADER(logger, "TitanCFOptions.blob_file_compression        : %s",
                    compression_str.c_str());
-  ROCKS_LOG_HEADER(logger, "TItanCFOptions.blob_file_compression_options: ");
-  ROCKS_LOG_HEADER(logger, "    window_bits : %d",
+  TITAN_LOG_HEADER(logger, "TItanCFOptions.blob_file_compression_options: ");
+  TITAN_LOG_HEADER(logger, "    window_bits : %d",
                    blob_file_compression_options.window_bits);
-  ROCKS_LOG_HEADER(logger, "    level : %d",
+  TITAN_LOG_HEADER(logger, "    level : %d",
                    blob_file_compression_options.level);
-  ROCKS_LOG_HEADER(logger, "    strategy : %d",
+  TITAN_LOG_HEADER(logger, "    strategy : %d",
                    blob_file_compression_options.strategy);
-  ROCKS_LOG_HEADER(logger, "    max_dict_bytes : %" PRIu32,
+  TITAN_LOG_HEADER(logger, "    max_dict_bytes : %" PRIu32,
                    blob_file_compression_options.max_dict_bytes);
-  ROCKS_LOG_HEADER(logger, "    zstd_max_train_bytes : %" PRIu32,
+  TITAN_LOG_HEADER(logger, "    zstd_max_train_bytes : %" PRIu32,
                    blob_file_compression_options.zstd_max_train_bytes);
-  ROCKS_LOG_HEADER(logger,
+  TITAN_LOG_HEADER(logger,
                    "TitanCFOptions.blob_file_target_size        : %" PRIu64,
                    blob_file_target_size);
-  ROCKS_LOG_HEADER(logger, "TitanCFOptions.blob_cache                   : %p",
+  TITAN_LOG_HEADER(logger, "TitanCFOptions.blob_cache                   : %p",
                    blob_cache.get());
   if (blob_cache != nullptr) {
-    ROCKS_LOG_HEADER(logger, "%s", blob_cache->GetPrintableOptions().c_str());
+    TITAN_LOG_HEADER(logger, "%s", blob_cache->GetPrintableOptions().c_str());
   }
-  ROCKS_LOG_HEADER(logger,
+  TITAN_LOG_HEADER(logger,
                    "TitanCFOptions.max_gc_batch_size            : %" PRIu64,
                    max_gc_batch_size);
-  ROCKS_LOG_HEADER(logger,
+  TITAN_LOG_HEADER(logger,
                    "TitanCFOptions.min_gc_batch_size            : %" PRIu64,
                    min_gc_batch_size);
-  ROCKS_LOG_HEADER(logger, "TitanCFOptions.blob_file_discardable_ratio  : %lf",
+  TITAN_LOG_HEADER(logger, "TitanCFOptions.blob_file_discardable_ratio  : %lf",
                    blob_file_discardable_ratio);
-  ROCKS_LOG_HEADER(logger, "TitanCFOptions.sample_file_size_ratio       : %lf",
+  TITAN_LOG_HEADER(logger, "TitanCFOptions.sample_file_size_ratio       : %lf",
                    sample_file_size_ratio);
-  ROCKS_LOG_HEADER(logger,
+  TITAN_LOG_HEADER(logger,
                    "TitanCFOptions.merge_small_file_threshold   : %" PRIu64,
                    merge_small_file_threshold);
   std::string blob_run_mode_str = "unknown";
   if (blob_run_mode_to_string.count(blob_run_mode) > 0) {
     blob_run_mode_str = blob_run_mode_to_string.at(blob_run_mode);
   }
-  ROCKS_LOG_HEADER(logger, "TitanCFOptions.blob_run_mode                : %s",
+  TITAN_LOG_HEADER(logger, "TitanCFOptions.blob_run_mode                : %s",
                    blob_run_mode_str.c_str());
 }
 

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -7,6 +7,7 @@
 #include <inttypes.h>
 
 #include "monitoring/statistics.h"
+#include "titan_logging.h"
 
 namespace rocksdb {
 namespace titandb {
@@ -109,7 +110,7 @@ void TitanTableBuilder::Add(const Slice& key, const Slice& value) {
         if (ok()) return;
       } else {
         ++error_read_cnt_;
-        ROCKS_LOG_DEBUG(db_options_.info_log,
+        TITAN_LOG_DEBUG(db_options_.info_log,
                         "Read file %" PRIu64 " error during level merge: %s",
                         index.file_number, get_status.ToString().c_str());
       }
@@ -148,7 +149,7 @@ void TitanTableBuilder::AddBlob(const ParsedInternalKey& ikey,
   if (!blob_builder_) {
     status_ = blob_manager_->NewFile(&blob_handle_);
     if (!ok()) return;
-    ROCKS_LOG_INFO(db_options_.info_log,
+    TITAN_LOG_INFO(db_options_.info_log,
                    "Titan table builder created new blob file %" PRIu64 ".",
                    blob_handle_->GetNumber());
     blob_builder_.reset(
@@ -225,7 +226,7 @@ void TitanTableBuilder::FinishBlobFile() {
     AddToBaseTable(contexts);
 
     if (s.ok() && ok()) {
-      ROCKS_LOG_INFO(db_options_.info_log,
+      TITAN_LOG_INFO(db_options_.info_log,
                      "Titan table builder finish output file %" PRIu64 ".",
                      blob_handle_->GetNumber());
       std::shared_ptr<BlobFileMeta> file = std::make_shared<BlobFileMeta>(
@@ -236,7 +237,7 @@ void TitanTableBuilder::FinishBlobFile() {
       finished_blobs_.push_back({file, std::move(blob_handle_)});
       blob_builder_.reset();
     } else {
-      ROCKS_LOG_WARN(
+      TITAN_LOG_WARN(
           db_options_.info_log,
           "Titan table builder finish failed. Delete output file %" PRIu64 ".",
           blob_handle_->GetNumber());
@@ -264,13 +265,13 @@ Status TitanTableBuilder::Finish() {
   base_builder_->Finish();
   status_ = blob_manager_->BatchFinishFiles(cf_id_, finished_blobs_);
   if (!status_.ok()) {
-    ROCKS_LOG_ERROR(db_options_.info_log,
+    TITAN_LOG_ERROR(db_options_.info_log,
                     "Titan table builder failed on finish: %s",
                     status_.ToString().c_str());
   }
   UpdateInternalOpStats();
   if (error_read_cnt_ > 0) {
-    ROCKS_LOG_ERROR(db_options_.info_log,
+    TITAN_LOG_ERROR(db_options_.info_log,
                     "Read file error %" PRIu64 " times during level merge",
                     error_read_cnt_);
   }
@@ -280,7 +281,7 @@ Status TitanTableBuilder::Finish() {
 void TitanTableBuilder::Abandon() {
   base_builder_->Abandon();
   if (blob_builder_) {
-    ROCKS_LOG_INFO(db_options_.info_log,
+    TITAN_LOG_INFO(db_options_.info_log,
                    "Titan table builder abandoned. Delete output file %" PRIu64
                    ".",
                    blob_handle_->GetNumber());

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -1987,7 +1987,7 @@ TEST_F(TitanDBTest, Config) {
 }
 
 #if defined(__linux) && !defined(TRAVIS)
-TEST_F(TitanDBTest, NoSpaceLeft) {
+TEST_F(TitanDBTest, DISABLED_NoSpaceLeft) {
   options_.disable_background_gc = false;
   system(("mkdir -p " + dbname_).c_str());
   system(("sudo mount -t tmpfs -o size=1m tmpfs " + dbname_).c_str());

--- a/src/titan_logging.h
+++ b/src/titan_logging.h
@@ -1,0 +1,71 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+//
+// Must not be included from any .h files to avoid polluting the namespace
+// with macros.
+
+#pragma once
+
+// This file is adapted from rocksdb/logging/logging.h.
+// We make a copy of this file because we want to have source files under
+// Titan directory being shorten.
+
+// Helper macros that include information about file name and line number
+#define TITAN_LOG_STRINGIFY(x) #x
+#define TITAN_LOG_TOSTRING(x) TITAN_LOG_STRINGIFY(x)
+#define TITAN_LOG_PREPEND_FILE_LINE(FMT) \
+  ("[%s:" TITAN_LOG_TOSTRING(__LINE__) "] " FMT)
+
+inline const char* TitanLogShorterFileName(const char* file) {
+  // 15 is the length of "titan_logging.h".
+  // If the name of this file changed, please change this number, too.
+  return file + (sizeof(__FILE__) > 15 ? sizeof(__FILE__) - 15 : 0);
+}
+
+// Don't inclide file/line info in HEADER level
+#define TITAN_LOG_HEADER(LGR, FMT, ...) \
+  rocksdb::Log(InfoLogLevel::HEADER_LEVEL, LGR, FMT, ##__VA_ARGS__)
+
+#define TITAN_LOG_DEBUG(LGR, FMT, ...)           \
+  rocksdb::Log(InfoLogLevel::DEBUG_LEVEL, LGR,   \
+               TITAN_LOG_PREPEND_FILE_LINE(FMT), \
+               TitanLogShorterFileName(__FILE__), ##__VA_ARGS__)
+
+#define TITAN_LOG_INFO(LGR, FMT, ...)            \
+  rocksdb::Log(InfoLogLevel::INFO_LEVEL, LGR,    \
+               TITAN_LOG_PREPEND_FILE_LINE(FMT), \
+               TitanLogShorterFileName(__FILE__), ##__VA_ARGS__)
+
+#define TITAN_LOG_WARN(LGR, FMT, ...)            \
+  rocksdb::Log(InfoLogLevel::WARN_LEVEL, LGR,    \
+               TITAN_LOG_PREPEND_FILE_LINE(FMT), \
+               TitanLogShorterFileName(__FILE__), ##__VA_ARGS__)
+
+#define TITAN_LOG_ERROR(LGR, FMT, ...)           \
+  rocksdb::Log(InfoLogLevel::ERROR_LEVEL, LGR,   \
+               TITAN_LOG_PREPEND_FILE_LINE(FMT), \
+               TitanLogShorterFileName(__FILE__), ##__VA_ARGS__)
+
+#define TITAN_LOG_FATAL(LGR, FMT, ...)           \
+  rocksdb::Log(InfoLogLevel::FATAL_LEVEL, LGR,   \
+               TITAN_LOG_PREPEND_FILE_LINE(FMT), \
+               TitanLogShorterFileName(__FILE__), ##__VA_ARGS__)
+
+#define TITAN_LOG_BUFFER(LOG_BUF, FMT, ...)                       \
+  rocksdb::LogToBuffer(LOG_BUF, TITAN_LOG_PREPEND_FILE_LINE(FMT), \
+                       TitanLogShorterFileName(__FILE__), ##__VA_ARGS__)
+
+#define TITAN_LOG_BUFFER_MAX_SZ(LOG_BUF, MAX_LOG_SIZE, FMT, ...) \
+  rocksdb::LogToBuffer(LOG_BUF, MAX_LOG_SIZE,                    \
+                       TITAN_LOG_PREPEND_FILE_LINE(FMT),         \
+                       TitanLogShorterFileName(__FILE__), ##__VA_ARGS__)
+
+#define TITAN_LOG_DETAILS(LGR, FMT, ...) \
+  ;  // due to overhead by default skip such lines
+// TITAN_LOG_DEBUG(LGR, FMT, ##__VA_ARGS__)

--- a/tools/blob_file_dump.cc
+++ b/tools/blob_file_dump.cc
@@ -1,0 +1,61 @@
+// Copyright 2021-present TiKV Project Authors. Licensed under Apache-2.0.
+
+#include "blob_file_iterator.h"
+#include "file/filename.h"
+#include "util/gflags_compat.h"
+
+using GFLAGS_NAMESPACE::ParseCommandLineFlags;
+using GFLAGS_NAMESPACE::SetUsageMessage;
+
+DEFINE_string(path, "", "Path of blob file.");
+DEFINE_bool(dump, false, "");
+
+#define handle_error(s, location)                                           \
+  if (!s.ok()) {                                                            \
+    fprintf(stderr, "error when %s: %s\n", location, s.ToString().c_str()); \
+    return 1;                                                               \
+  }
+
+namespace rocksdb {
+namespace titandb {
+
+int blob_file_dump() {
+  Env* env = Env::Default();
+  Status s;
+
+  std::string file_name = FLAGS_path;
+  uint64_t file_size = 0;
+  s = env->GetFileSize(file_name, &file_size);
+  handle_error(s, "getting file size");
+
+  std::unique_ptr<RandomAccessFileReader> file;
+  std::unique_ptr<RandomAccessFile> f;
+  s = env->NewRandomAccessFile(file_name, &f, EnvOptions());
+  handle_error(s, "open file");
+  file.reset(new RandomAccessFileReader(std::move(f), file_name));
+
+  std::unique_ptr<BlobFileIterator> iter(new BlobFileIterator(
+      std::move(file), 1 /*fake file number*/, file_size, TitanCFOptions()));
+
+  iter->SeekToFirst();
+  while (iter->Valid()) {
+    handle_error(iter->status(), "status");
+    if (FLAGS_dump) {
+      std::string key = iter->key().ToString(true);
+      std::string value = iter->value().ToString(true);
+      fprintf(stdout, "%s: %s\n", key.c_str(), value.c_str());
+    }
+  }
+  handle_error(iter->status(), "reading blob file");
+  return 0;
+}
+
+}  // namespace titandb
+}  // namespace rocksdb
+
+int main(int argc, char** argv) {
+  SetUsageMessage(std::string("\nUSAGE\n") + std::string(argv[0]) +
+                  " [OPTIONS]...");
+  ParseCommandLineFlags(&argc, &argv, true);
+  return rocksdb::titandb::blob_file_dump();
+}


### PR DESCRIPTION
cherry-picking #221 

To support dictionary compression we added a v2 blob file header to store extra flags. However, the check in BlobFileReader , when reading a v1 blob file, falsely asserted the file header is shorter than expected:
https://github.com/tikv/titan/blob/ecb5cba016096309cbd9b566bdc4ce62307527a0/src/blob_file_reader.cc#L103
https://github.com/tikv/titan/blob/ecb5cba016096309cbd9b566bdc4ce62307527a0/src/blob_format.h#L394
Refactoring the code to bypass the check to fix the issue.

The issue is introduced in https://github.com/tikv/titan/pull/189. TiKV is affected when Titan is enabled and upgrade from pre-5.0 versions to >=5.0.0 versions. It will make TiKV fall in crash loop.

Also adding a titan_blob_file_dump tool to dump blob file content.

Signed-off-by: Yi Wu <yiwu@pingcap.com>