### PR TITLE
Fix a problem in TitanTableBuilder::Add()

### DIFF
--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -70,7 +70,7 @@ void TitanTableBuilder::Add(const Slice& key, const Slice& value) {
              cf_options_.blob_run_mode == TitanBlobRunMode::kNormal) {
     bool is_small_kv = value.size() < cf_options_.min_blob_size;
     if (is_small_kv) {
-      AddSmall(key, ikey, value);
+      AddBase(key, ikey, value);
       return;
     } else {
       // We write to blob file and insert index
@@ -106,17 +106,17 @@ void TitanTableBuilder::Add(const Slice& key, const Slice& value) {
                         index.file_number, get_status.ToString().c_str());
       }
     }
-    AddSmall(key, ikey, value);
+    AddBase(key, ikey, value);
   } else {
     // Mainly processing kTypeMerge and kTypeBlobIndex in both flushing and
     // compaction.
-    AddSmall(key, ikey, value);
+    AddBase(key, ikey, value);
   }
 }
 
-void TitanTableBuilder::AddSmall(const Slice& key,
-                                 const ParsedInternalKey& parsedKey,
-                                 const Slice& value) {
+void TitanTableBuilder::AddBase(const Slice& key,
+                                const ParsedInternalKey& parsedKey,
+                                const Slice& value) {
   if (builder_unbuffered()) {
     // We can directly append this into SST safely, without disorder issue.
     // Only when base_builder_ is in unbuffered state
@@ -186,10 +186,10 @@ void TitanTableBuilder::AddBlob(const ParsedInternalKey& ikey,
     FinishBlobFile();
   }
 
-  AddToBaseTable(contexts);
+  AddBlobResultsToBase(contexts);
 }
 
-void TitanTableBuilder::AddToBaseTable(
+void TitanTableBuilder::AddBlobResultsToBase(
     const BlobFileBuilder::OutContexts& contexts) {
   if (contexts.empty()) return;
   for (const std::unique_ptr<BlobFileBuilder::BlobRecordContext>& ctx :
@@ -229,7 +229,7 @@ void TitanTableBuilder::FinishBlobFile() {
     s = blob_builder_->Finish(&contexts);
     UpdateIOBytes(prev_bytes_read, prev_bytes_written, &io_bytes_read_,
                   &io_bytes_written_);
-    AddToBaseTable(contexts);
+    AddBlobResultsToBase(contexts);
 
     if (s.ok() && ok()) {
       TITAN_LOG_INFO(db_options_.info_log,

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -183,7 +183,8 @@ void TitanTableBuilder::AddBlob(const ParsedInternalKey& ikey,
       cf_options_.blob_file_target_size) {
     // if blob file hit the size limit, we have to finish it
     // in this case, when calling `BlobFileBuilder::Finish`, builder will be in
-    // unbuffered state, so it will not trigger another `AddBlobResultsToBase` call
+    // unbuffered state, so it will not trigger another `AddBlobResultsToBase`
+    // call
     FinishBlobFile();
   }
 

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -122,8 +122,8 @@ void TitanTableBuilder::AddSmall(const Slice& key,
     // Only when base_builder_ is in unbuffered state
     base_builder_->Add(key, value);
   } else {
-    // We have to let builder to cache this KV pair, and it will be returned
-    // when state changed
+    // We have to let builder to cache this KV pair, and it will be flushed to base table
+    // when the state changes to unbuffered
     std::unique_ptr<BlobFileBuilder::BlobRecordContext> ctx =
         NewCachedRecordContext(parsedKey, value);
     blob_builder_->AddSmall(std::move(ctx));

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -70,16 +70,7 @@ void TitanTableBuilder::Add(const Slice& key, const Slice& value) {
              cf_options_.blob_run_mode == TitanBlobRunMode::kNormal) {
     bool is_small_kv = value.size() < cf_options_.min_blob_size;
     if (is_small_kv) {
-      if (builder_unbuffered()) {
-        // We can append this into SST safely, without disorder issue.
-        base_builder_->Add(key, value);
-      } else {
-        // We have to let builder to cache this KV pair, and it will be returned
-        // when state changed
-        std::unique_ptr<BlobFileBuilder::BlobRecordContext> ctx =
-            NewCachedRecordContext(ikey, value);
-        blob_builder_->AddSmall(std::move(ctx));
-      }
+      AddSmallToTableAdaptively(key, ikey, value);
       return;
     } else {
       // We write to blob file and insert index
@@ -115,21 +106,24 @@ void TitanTableBuilder::Add(const Slice& key, const Slice& value) {
                         index.file_number, get_status.ToString().c_str());
       }
     }
-    if (builder_unbuffered()) {
-      base_builder_->Add(key, value);
-    } else {
-      std::unique_ptr<BlobFileBuilder::BlobRecordContext> ctx =
-          NewCachedRecordContext(ikey, value);
-      blob_builder_->AddSmall(std::move(ctx));
-    }
+    AddSmallToTableAdaptively(key, ikey, value);
   } else {
-    if (builder_unbuffered()) {
-      base_builder_->Add(key, value);
-    } else {
-      std::unique_ptr<BlobFileBuilder::BlobRecordContext> ctx =
-              NewCachedRecordContext(ikey, value);
-      blob_builder_->AddSmall(std::move(ctx));
-    }
+    // Mainly processing kTypeMerge and kTypeBlobIndex in both flushing and compaction.
+    AddSmallToTableAdaptively(key, ikey, value);
+  }
+}
+
+void TitanTableBuilder::AddSmallToTableAdaptively(const Slice& key, const ParsedInternalKey& parsedKey, const Slice& value){
+  if (builder_unbuffered()) {
+    // We can directly append this into SST safely, without disorder issue.
+    // Only when base_builder_ is in unbuffered state
+    base_builder_->Add(key, value);
+  } else {
+    // We have to let builder to cache this KV pair, and it will be returned
+    // when state changed
+    std::unique_ptr<BlobFileBuilder::BlobRecordContext> ctx =
+            NewCachedRecordContext(parsedKey, value);
+    blob_builder_->AddSmall(std::move(ctx));
   }
 }
 

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -117,6 +117,7 @@ void TitanTableBuilder::Add(const Slice& key, const Slice& value) {
 void TitanTableBuilder::AddBase(const Slice& key,
                                 const ParsedInternalKey& parsedKey,
                                 const Slice& value) {
+  // "parsedKey" was parsed from "key" (i.e., an internal key).
   if (builder_unbuffered()) {
     // We can directly append this into SST safely, without disorder issue.
     // Only when base_builder_ is in unbuffered state

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -70,7 +70,7 @@ void TitanTableBuilder::Add(const Slice& key, const Slice& value) {
              cf_options_.blob_run_mode == TitanBlobRunMode::kNormal) {
     bool is_small_kv = value.size() < cf_options_.min_blob_size;
     if (is_small_kv) {
-      AddSmallToTableAdaptively(key, ikey, value);
+      AddToBaseTable(key, ikey, value);
       return;
     } else {
       // We write to blob file and insert index
@@ -106,14 +106,14 @@ void TitanTableBuilder::Add(const Slice& key, const Slice& value) {
                         index.file_number, get_status.ToString().c_str());
       }
     }
-    AddSmallToTableAdaptively(key, ikey, value);
+    AddToBaseTable(key, ikey, value);
   } else {
     // Mainly processing kTypeMerge and kTypeBlobIndex in both flushing and compaction.
-    AddSmallToTableAdaptively(key, ikey, value);
+    AddToBaseTable(key, ikey, value);
   }
 }
 
-void TitanTableBuilder::AddSmallToTableAdaptively(const Slice& key, const ParsedInternalKey& parsedKey, const Slice& value){
+void TitanTableBuilder::AddToBaseTable(const Slice& key, const ParsedInternalKey& parsedKey, const Slice& value){
   if (builder_unbuffered()) {
     // We can directly append this into SST safely, without disorder issue.
     // Only when base_builder_ is in unbuffered state

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -123,8 +123,13 @@ void TitanTableBuilder::Add(const Slice& key, const Slice& value) {
       blob_builder_->AddSmall(std::move(ctx));
     }
   } else {
-    assert(builder_unbuffered());
-    base_builder_->Add(key, value);
+    if (builder_unbuffered()) {
+      base_builder_->Add(key, value);
+    } else {
+      std::unique_ptr<BlobFileBuilder::BlobRecordContext> ctx =
+              NewCachedRecordContext(ikey, value);
+      blob_builder_->AddSmall(std::move(ctx));
+    }
   }
 }
 

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -108,12 +108,15 @@ void TitanTableBuilder::Add(const Slice& key, const Slice& value) {
     }
     AddToBaseTable(key, ikey, value);
   } else {
-    // Mainly processing kTypeMerge and kTypeBlobIndex in both flushing and compaction.
+    // Mainly processing kTypeMerge and kTypeBlobIndex in both flushing and
+    // compaction.
     AddToBaseTable(key, ikey, value);
   }
 }
 
-void TitanTableBuilder::AddToBaseTable(const Slice& key, const ParsedInternalKey& parsedKey, const Slice& value){
+void TitanTableBuilder::AddToBaseTable(const Slice& key,
+                                       const ParsedInternalKey& parsedKey,
+                                       const Slice& value) {
   if (builder_unbuffered()) {
     // We can directly append this into SST safely, without disorder issue.
     // Only when base_builder_ is in unbuffered state
@@ -122,7 +125,7 @@ void TitanTableBuilder::AddToBaseTable(const Slice& key, const ParsedInternalKey
     // We have to let builder to cache this KV pair, and it will be returned
     // when state changed
     std::unique_ptr<BlobFileBuilder::BlobRecordContext> ctx =
-            NewCachedRecordContext(parsedKey, value);
+        NewCachedRecordContext(parsedKey, value);
     blob_builder_->AddSmall(std::move(ctx));
   }
 }

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -122,8 +122,8 @@ void TitanTableBuilder::AddSmall(const Slice& key,
     // Only when base_builder_ is in unbuffered state
     base_builder_->Add(key, value);
   } else {
-    // We have to let builder to cache this KV pair, and it will be flushed to base table
-    // when the state changes to unbuffered
+    // We have to let builder to cache this KV pair, and it will be flushed to
+    // base table when the state changes to unbuffered
     std::unique_ptr<BlobFileBuilder::BlobRecordContext> ctx =
         NewCachedRecordContext(parsedKey, value);
     blob_builder_->AddSmall(std::move(ctx));

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -182,7 +182,7 @@ void TitanTableBuilder::AddBlob(const ParsedInternalKey& ikey,
       cf_options_.blob_file_target_size) {
     // if blob file hit the size limit, we have to finish it
     // in this case, when calling `BlobFileBuilder::Finish`, builder will be in
-    // unbuffered state, so it will not trigger another `AddSmall` call
+    // unbuffered state, so it will not trigger another `AddBlobResultsToBase` call
     FinishBlobFile();
   }
 

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -70,7 +70,7 @@ void TitanTableBuilder::Add(const Slice& key, const Slice& value) {
              cf_options_.blob_run_mode == TitanBlobRunMode::kNormal) {
     bool is_small_kv = value.size() < cf_options_.min_blob_size;
     if (is_small_kv) {
-      AddToBaseTable(key, ikey, value);
+      AddSmall(key, ikey, value);
       return;
     } else {
       // We write to blob file and insert index
@@ -106,17 +106,17 @@ void TitanTableBuilder::Add(const Slice& key, const Slice& value) {
                         index.file_number, get_status.ToString().c_str());
       }
     }
-    AddToBaseTable(key, ikey, value);
+    AddSmall(key, ikey, value);
   } else {
     // Mainly processing kTypeMerge and kTypeBlobIndex in both flushing and
     // compaction.
-    AddToBaseTable(key, ikey, value);
+    AddSmall(key, ikey, value);
   }
 }
 
-void TitanTableBuilder::AddToBaseTable(const Slice& key,
-                                       const ParsedInternalKey& parsedKey,
-                                       const Slice& value) {
+void TitanTableBuilder::AddSmall(const Slice& key,
+                                 const ParsedInternalKey& parsedKey,
+                                 const Slice& value) {
   if (builder_unbuffered()) {
     // We can directly append this into SST safely, without disorder issue.
     // Only when base_builder_ is in unbuffered state
@@ -182,7 +182,7 @@ void TitanTableBuilder::AddBlob(const ParsedInternalKey& ikey,
       cf_options_.blob_file_target_size) {
     // if blob file hit the size limit, we have to finish it
     // in this case, when calling `BlobFileBuilder::Finish`, builder will be in
-    // unbuffered state, so it will not trigger another `AddToBaseTable` call
+    // unbuffered state, so it will not trigger another `AddSmall` call
     FinishBlobFile();
   }
 

--- a/src/table_builder.h
+++ b/src/table_builder.h
@@ -71,7 +71,8 @@ class TitanTableBuilder : public TableBuilder {
   Status GetBlobRecord(const BlobIndex& index, BlobRecord* record,
                        PinnableSlice* buffer);
 
-  void AddToBaseTable(const Slice& key, const ParsedInternalKey& parsedKey, const Slice& value);
+  void AddToBaseTable(const Slice& key, const ParsedInternalKey& parsedKey,
+                      const Slice& value);
 
   Status status_;
   uint32_t cf_id_;

--- a/src/table_builder.h
+++ b/src/table_builder.h
@@ -71,6 +71,8 @@ class TitanTableBuilder : public TableBuilder {
   Status GetBlobRecord(const BlobIndex& index, BlobRecord* record,
                        PinnableSlice* buffer);
 
+  void AddSmallToTableAdaptively(const Slice& key, const ParsedInternalKey& parsedKey, const Slice& value);
+
   Status status_;
   uint32_t cf_id_;
   TitanDBOptions db_options_;

--- a/src/table_builder.h
+++ b/src/table_builder.h
@@ -71,8 +71,8 @@ class TitanTableBuilder : public TableBuilder {
   Status GetBlobRecord(const BlobIndex& index, BlobRecord* record,
                        PinnableSlice* buffer);
 
-  void AddToBaseTable(const Slice& key, const ParsedInternalKey& parsedKey,
-                      const Slice& value);
+  void AddSmall(const Slice& key, const ParsedInternalKey& parsedKey,
+                const Slice& value);
 
   Status status_;
   uint32_t cf_id_;

--- a/src/table_builder.h
+++ b/src/table_builder.h
@@ -60,7 +60,7 @@ class TitanTableBuilder : public TableBuilder {
 
   void AddBlob(const ParsedInternalKey& ikey, const Slice& value);
 
-  void AddToBaseTable(const BlobFileBuilder::OutContexts& contexts);
+  void AddBlobResultsToBase(const BlobFileBuilder::OutContexts& contexts);
 
   bool ShouldMerge(const std::shared_ptr<BlobFileMeta>& file);
 
@@ -71,8 +71,8 @@ class TitanTableBuilder : public TableBuilder {
   Status GetBlobRecord(const BlobIndex& index, BlobRecord* record,
                        PinnableSlice* buffer);
 
-  void AddSmall(const Slice& key, const ParsedInternalKey& parsedKey,
-                const Slice& value);
+  void AddBase(const Slice& key, const ParsedInternalKey& parsedKey,
+               const Slice& value);
 
   Status status_;
   uint32_t cf_id_;

--- a/src/table_builder.h
+++ b/src/table_builder.h
@@ -71,7 +71,7 @@ class TitanTableBuilder : public TableBuilder {
   Status GetBlobRecord(const BlobIndex& index, BlobRecord* record,
                        PinnableSlice* buffer);
 
-  void AddSmallToTableAdaptively(const Slice& key, const ParsedInternalKey& parsedKey, const Slice& value);
+  void AddToBaseTable(const Slice& key, const ParsedInternalKey& parsedKey, const Slice& value);
 
   Status status_;
   uint32_t cf_id_;

--- a/src/table_builder_test.cc
+++ b/src/table_builder_test.cc
@@ -495,10 +495,28 @@ TEST_F(TableBuilderTest, DictCompressDisorder) {
     std::string key(1, i);
     InternalKey ikey(key, 1, kTypeValue);
     std::string value;
-    if (i % 2 == 0) {
+    if (i % 4 == 0) {
       value = std::string(1, i);
-    } else {
+    } else if (i % 4 == 1){
       value = std::string(kMinBlobSize, i);
+    } else if (i % 4 == 2){
+      ikey.Set(key, 1, kTypeBlobIndex);
+      BlobIndex blobIndex;
+      // set different values in different fields
+      blobIndex.file_number = i;
+      blobIndex.blob_handle.size = i*2+1;
+      blobIndex.blob_handle.offset = i*3+2;
+      blobIndex.EncodeTo(&value);
+    } else {
+      ikey.Set(key, 1, kTypeMerge);
+      MergeBlobIndex mergeIndex;
+      // set different values in different fields
+      mergeIndex.file_number = i;
+      mergeIndex.blob_handle.size = i*2+1;
+      mergeIndex.blob_handle.offset = i*3+2;
+      mergeIndex.source_file_number = i*4+3;
+      mergeIndex.source_file_offset = i*5+4;
+      mergeIndex.EncodeTo(&value);
     }
     table_builder->Add(ikey.Encode(), value);
   }
@@ -523,10 +541,10 @@ TEST_F(TableBuilderTest, DictCompressDisorder) {
     ASSERT_TRUE(ParseInternalKey(iter->key(), &ikey));
     // check order
     ASSERT_EQ(ikey.user_key, key);
-    if (i % 2 == 0) {
+    if (i % 4 == 0) {
       ASSERT_EQ(ikey.type, kTypeValue);
       ASSERT_EQ(iter->value(), std::string(1, i));
-    } else {
+    } else if (i % 4 == 1) {
       ASSERT_EQ(ikey.type, kTypeBlobIndex);
       BlobIndex index;
       ASSERT_OK(DecodeInto(iter->value(), &index));
@@ -536,6 +554,24 @@ TEST_F(TableBuilderTest, DictCompressDisorder) {
       ASSERT_OK(blob_reader->Get(ro, index.blob_handle, &record, &buffer));
       ASSERT_EQ(record.key, key);
       ASSERT_EQ(record.value, std::string(kMinBlobSize, i));
+    }else if (i % 4 == 2){
+      ASSERT_EQ(ikey.type, kTypeBlobIndex);
+      BlobIndex index;
+      // We do not have corresponding blob file in this test, so we only check BlobIndex.
+      ASSERT_OK(DecodeInto(iter->value(), &index));
+      ASSERT_EQ(index.file_number, i);
+      ASSERT_EQ(index.blob_handle.size, i*2+1);
+      ASSERT_EQ(index.blob_handle.offset, i*3+2);
+    }else{
+      ASSERT_EQ(ikey.type, kTypeMerge);
+      MergeBlobIndex mergeIndex;
+      // We do not have corresponding blob file in this test, so we only check MergeBlobIndex.
+      ASSERT_OK(DecodeInto(iter->value(), &mergeIndex));
+      ASSERT_EQ(mergeIndex.file_number, i);
+      ASSERT_EQ(mergeIndex.blob_handle.size, i*2+1);
+      ASSERT_EQ(mergeIndex.blob_handle.offset, i*3+2);
+      ASSERT_EQ(mergeIndex.source_file_number, i*4+3);
+      ASSERT_EQ(mergeIndex.source_file_offset, i*5+4);
     }
     iter->Next();
   }

--- a/src/table_builder_test.cc
+++ b/src/table_builder_test.cc
@@ -497,25 +497,25 @@ TEST_F(TableBuilderTest, DictCompressDisorder) {
     std::string value;
     if (i % 4 == 0) {
       value = std::string(1, i);
-    } else if (i % 4 == 1){
+    } else if (i % 4 == 1) {
       value = std::string(kMinBlobSize, i);
-    } else if (i % 4 == 2){
+    } else if (i % 4 == 2) {
       ikey.Set(key, 1, kTypeBlobIndex);
       BlobIndex blobIndex;
       // set different values in different fields
       blobIndex.file_number = i;
-      blobIndex.blob_handle.size = i*2+1;
-      blobIndex.blob_handle.offset = i*3+2;
+      blobIndex.blob_handle.size = i * 2 + 1;
+      blobIndex.blob_handle.offset = i * 3 + 2;
       blobIndex.EncodeTo(&value);
     } else {
       ikey.Set(key, 1, kTypeMerge);
       MergeBlobIndex mergeIndex;
       // set different values in different fields
       mergeIndex.file_number = i;
-      mergeIndex.blob_handle.size = i*2+1;
-      mergeIndex.blob_handle.offset = i*3+2;
-      mergeIndex.source_file_number = i*4+3;
-      mergeIndex.source_file_offset = i*5+4;
+      mergeIndex.blob_handle.size = i * 2 + 1;
+      mergeIndex.blob_handle.offset = i * 3 + 2;
+      mergeIndex.source_file_number = i * 4 + 3;
+      mergeIndex.source_file_offset = i * 5 + 4;
       mergeIndex.EncodeTo(&value);
     }
     table_builder->Add(ikey.Encode(), value);
@@ -554,24 +554,26 @@ TEST_F(TableBuilderTest, DictCompressDisorder) {
       ASSERT_OK(blob_reader->Get(ro, index.blob_handle, &record, &buffer));
       ASSERT_EQ(record.key, key);
       ASSERT_EQ(record.value, std::string(kMinBlobSize, i));
-    }else if (i % 4 == 2){
+    } else if (i % 4 == 2) {
       ASSERT_EQ(ikey.type, kTypeBlobIndex);
       BlobIndex index;
-      // We do not have corresponding blob file in this test, so we only check BlobIndex.
+      // We do not have corresponding blob file in this test, so we only check
+      // BlobIndex.
       ASSERT_OK(DecodeInto(iter->value(), &index));
       ASSERT_EQ(index.file_number, i);
-      ASSERT_EQ(index.blob_handle.size, i*2+1);
-      ASSERT_EQ(index.blob_handle.offset, i*3+2);
-    }else{
+      ASSERT_EQ(index.blob_handle.size, i * 2 + 1);
+      ASSERT_EQ(index.blob_handle.offset, i * 3 + 2);
+    } else {
       ASSERT_EQ(ikey.type, kTypeMerge);
       MergeBlobIndex mergeIndex;
-      // We do not have corresponding blob file in this test, so we only check MergeBlobIndex.
+      // We do not have corresponding blob file in this test, so we only check
+      // MergeBlobIndex.
       ASSERT_OK(DecodeInto(iter->value(), &mergeIndex));
       ASSERT_EQ(mergeIndex.file_number, i);
-      ASSERT_EQ(mergeIndex.blob_handle.size, i*2+1);
-      ASSERT_EQ(mergeIndex.blob_handle.offset, i*3+2);
-      ASSERT_EQ(mergeIndex.source_file_number, i*4+3);
-      ASSERT_EQ(mergeIndex.source_file_offset, i*5+4);
+      ASSERT_EQ(mergeIndex.blob_handle.size, i * 2 + 1);
+      ASSERT_EQ(mergeIndex.blob_handle.offset, i * 3 + 2);
+      ASSERT_EQ(mergeIndex.source_file_number, i * 4 + 3);
+      ASSERT_EQ(mergeIndex.source_file_offset, i * 5 + 4);
     }
     iter->Next();
   }


### PR DESCRIPTION
Close #232.

Fix a problem in a corner case:
Flushing a memtable, and it has a few kTypeValue in the first and follows with a kTypeBlobIndex or kTypeMerge generated by GC.
These kTypeValues are written to a blob file first, which makes the BlobFileBuilder is still in the Buffered state because the size of them is not enough.
In this case, the following kTypeBlobIndex or kTypeMerge must be cached in the workflow of TitanTableBuilder::Add().