### PR TITLE
Check a status in InstallOutputBlobFiles and Rewrite BatchWriteNewIndices

### DIFF
--- a/src/blob_gc_job.cc
+++ b/src/blob_gc_job.cc
@@ -415,6 +415,9 @@ Status BlobGCJob::InstallOutputBlobFiles() {
   for (auto& builder : blob_file_builders_) {
     BlobFileBuilder::OutContexts contexts;
     s = builder.second->Finish(&contexts);
+    if (!s.ok()) {
+      break;
+    }
     BatchWriteNewIndices(contexts, &s);
     if (!s.ok()) {
       break;

--- a/src/blob_gc_job.h
+++ b/src/blob_gc_job.h
@@ -90,7 +90,7 @@ class BlobGCJob {
   uint64_t io_bytes_written_ = 0;
 
   Status DoRunGC();
-  void BatchWriteNewIndices(BlobFileBuilder::OutContexts &contexts, Status *s);
+  Status BatchWriteNewIndices(const BlobFileBuilder::OutContexts& contexts);
   Status BuildIterator(std::unique_ptr<BlobFileMergeIterator> *result);
   Status DiscardEntry(const Slice &key, const BlobIndex &blob_index,
                       bool *discardable);


### PR DESCRIPTION
The issue is here #238.
I push 3 commits. 
One is add a status check.
One is change the `void BatchWriteNewIndices(BlobFileBuilder::OutContexts& contexts, Status* s)` to `Status BatchWriteNewIndices(BlobFileBuilder::OutContexts& contexts)`
One is delete MergeBlobIndex if we just don't use it when gc_merge_rewrite_ = false.

If you want, I can squash the 3 commit into 1 commit.