### PR TITLE
add -Wno-array-bounds flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ option(CODE_COVERAGE "Generate code coverage report." OFF)
 
 if (CMAKE_BUILD_TYPE STREQUAL "Release")
   set(WITH_TITAN_TESTS OFF)
-  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  if (CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-array-bounds")
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,9 @@ option(CODE_COVERAGE "Generate code coverage report." OFF)
 
 if (CMAKE_BUILD_TYPE STREQUAL "Release")
   set(WITH_TITAN_TESTS OFF)
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-array-bounds")
+  endif()
 endif()
 
 if(GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")

--- a/include/titan/options.h
+++ b/include/titan/options.h
@@ -203,7 +203,7 @@ struct ImmutableTitanCFOptions {
   uint64_t min_gc_batch_size;
 
   double blob_file_discardable_ratio;
-  
+
   uint64_t merge_small_file_threshold;
 
   bool level_merge;

--- a/src/blob_gc_job_test.cc
+++ b/src/blob_gc_job_test.cc
@@ -141,7 +141,6 @@ class BlobGCJobTest : public testing::Test {
       cf_options.merge_small_file_threshold = 0;
     }
     cf_options.blob_file_discardable_ratio = 0.4;
-    cf_options.sample_file_size_ratio = 1;
 
     std::unique_ptr<BlobGC> blob_gc;
     {


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

We encounter a compile problem in https://github.com/CeresDB/ceresdb/issues/16 . Related (maybe) error log:
```
  In member function ‘std::__atomic_base<_IntTp>::__int_type std::__atomic_base<_IntTp>::fetch_add(__int_type, std::memory_order) [with _ITp = long unsigned int]’,
      inlined from ‘void rocksdb::StatisticsImpl<TICKER_MAX, HISTOGRAM_MAX>::recordTick(uint32_t, uint64_t) [with unsigned int TICKER_MAX = 145; unsigned int HISTOGRAM_MAX = 49]’ at /home/paomian/.cargo/git/checkouts/rust-rocksdb-a9a28e74c6ead8ef/7737841/librocksdb_sys/libtitan_sys/../rocksdb/monitoring/statistics_impl.h:205:59,
      inlined from ‘void rocksdb::RecordTick(Statistics*, uint32_t, uint64_t)’ at /home/paomian/.cargo/git/checkouts/rust-rocksdb-a9a28e74c6ead8ef/7737841/librocksdb_sys/libtitan_sys/../rocksdb/monitoring/statistics.h:33:27,
      inlined from ‘virtual rocksdb::Status rocksdb::titandb::TitanDBImpl::FileManager::BatchFinishFiles(uint32_t, const std::vector<std::pair<std::shared_ptr<rocksdb::titandb::BlobFileMeta>, std::unique_ptr<rocksdb::titandb::BlobFileHandle> > >&)’ at /home/paomian/.cargo/git/checkouts/rust-rocksdb-a9a28e74c6ead8ef/7737841/librocksdb_sys/libtitan_sys/titan/src/db_impl.cc:67:17:
  /usr/include/c++/12/bits/atomic_base.h:618:35: error: array subscript 153 is above array bounds of ‘std::atomic_uint_fast64_t [145]’ {aka ‘std::atomic<long unsigned int> [145]’} [-Werror=array-bounds]
```
I think this is reproducible under GCC 12.1
```
$ gcc --version                              
gcc (GCC) 12.1.0
Copyright (C) 2022 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```


This patch works for me but I'm not sure whether it is correct. I suspect this is a false positive warning and simply ignore it.