### PR TITLE
fix: consider other release build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,11 +47,12 @@ option(WITH_TITAN_TOOLS "Build with tools." ON)
 option(TRAVIS "Building in Travis." OFF)
 option(CODE_COVERAGE "Generate code coverage report." OFF)
 
+if (CMAKE_COMPILER_IS_GNUCXX)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-array-bounds")
+endif()
+
 if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(WITH_TITAN_TESTS OFF)
-  if (CMAKE_COMPILER_IS_GNUCXX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-array-bounds")
-  endif()
 endif()
 
 if(GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ option(WITH_TITAN_TOOLS "Build with tools." ON)
 option(TRAVIS "Building in Travis." OFF)
 option(CODE_COVERAGE "Generate code coverage report." OFF)
 
-if (CMAKE_BUILD_TYPE STREQUAL "Release")
+if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(WITH_TITAN_TESTS OFF)
   if (CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-array-bounds")
@@ -101,7 +101,7 @@ if (WITH_TITAN_TESTS OR WITH_TITAN_TOOLS)
   endif()
 endif()
 
-if (WITH_TITAN_TESTS AND (NOT CMAKE_BUILD_TYPE STREQUAL "Release"))
+if (WITH_TITAN_TESTS AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
   include(CTest)
   include_directories(SYSTEM ${ROCKSDB_DIR}/third-party/gtest-1.7.0/fused-src)
   set(TESTS


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

Still the `-Wno-array-bounds` problem🤧 I haven't considered that not all `CMAKE_BUILD_TYPE` are "Release"... There are actually four types in this enum https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html

When a rust project set its `profile.release.debug` to `true` the depended rocksdb/titan will be built with `RelWithDebInfo`. This PR change the condition to "whether debug or not" since other three types are release (but I haven't try when it will be `MinSizeRel`).

I also moved out `-Wno-array-bounds` to make it more robust.