### PR TITLE
respect `blob-run-mode` during GC

### DIFF
--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -1100,6 +1100,10 @@ Status TitanDBImpl::SetOptions(
       TitanColumnFamilyInfo& cf_info = cf_info_[cf_id];
       cf_info.titan_table_factory->SetBlobRunMode(blob_run_mode);
       cf_info.mutable_cf_options.blob_run_mode = blob_run_mode;
+      auto bs = blob_file_set_->GetBlobStorage(cf_id).lock();
+      if (bs != nullptr) {
+        bs->SetBlobRunMode(blob_run_mode);
+      }
     }
   }
   return Status::OK();


### PR DESCRIPTION
Close #259

Also fix the bug that blob-run-mode changes doesn't apply to blob storage.

Signed-off-by: tabokie <xy.tao@outlook.com>