### PR TITLE
Avoid holding mutex when syncing manifest

### DIFF
--- a/src/blob_file_set.cc
+++ b/src/blob_file_set.cc
@@ -210,6 +210,7 @@ Status BlobFileSet::WriteSnapshot(log::Writer* log) {
   return s;
 }
 
+// A helper class to collect all the information needed for manifest write.
 struct BlobFileSet::ManifestWriter {
   Status status;
   bool done;
@@ -236,11 +237,14 @@ Status BlobFileSet::LogAndApply(VersionEdit& edit) {
   ManifestWriter writer(mutex_, collector, edit);
   manifest_writers_.push_back(&writer);
 
+  // The head of queue is the writer that is responsible for writing manifest
+  // for the group. Thw write group makes sure only one thread is writing to the
+  // manifest, otherwise the manifest will be corrupted.
   while (!writer.done && &writer != manifest_writers_.front()) {
     writer.cv.Wait();
   }
   if (writer.done) {
-    // the writer is handled by other writers, just return here
+    // The writer is handled by the head of queue's writer, just return here
     return writer.status;
   }
 
@@ -275,13 +279,14 @@ Status BlobFileSet::LogAndApply(VersionEdit& edit) {
 
   if (s.ok()) {
     for (auto& c : collectors) {
+      // Apply the version edit to blob file set
       s = c->Apply(*this);
       if (!s.ok()) {
         break;
       }
     }
   }
-  // wake up all the waiting writers
+  // Wake up all the waiting writers
   while (true) {
     ManifestWriter* ready = manifest_writers_.front();
     manifest_writers_.pop_front();

--- a/src/blob_file_set.cc
+++ b/src/blob_file_set.cc
@@ -217,9 +217,9 @@ struct BlobFileSet::ManifestWriter {
   EditCollector& collector;
   VersionEdit& edit;
 
-  explicit ManifestWriter(port::Mutex* mu, EditCollector& collector,
-                          VersionEdit& edit)
-      : done(false), cv(mu), collector(collector), edit(edit) {}
+  explicit ManifestWriter(port::Mutex* mu, EditCollector& _collector,
+                          VersionEdit& _edit)
+      : done(false), cv(mu), collector(_collector), edit(_edit) {}
 };
 
 Status BlobFileSet::LogAndApply(VersionEdit& edit) {

--- a/src/blob_file_set.h
+++ b/src/blob_file_set.h
@@ -34,7 +34,7 @@ struct LogReporter : public log::Reader::Reporter {
 class BlobFileSet {
  public:
   explicit BlobFileSet(const TitanDBOptions& options, TitanStats* stats,
-                       std::atomic<bool>* initialized);
+                       std::atomic<bool>* initialized, port::Mutex* mutex);
 
   // Sets up the storage specified in "options.dirname".
   // If the manifest doesn't exist, it will create one.
@@ -97,6 +97,8 @@ class BlobFileSet {
   bool IsOpened() { return opened_.load(std::memory_order_acquire); }
 
  private:
+  struct ManifestWriter;
+
   friend class BlobFileSizeCollectorTest;
   friend class VersionTest;
 
@@ -134,6 +136,8 @@ class BlobFileSet {
   std::unique_ptr<log::Writer> manifest_;
   std::atomic<uint64_t> next_file_number_{1};
   uint64_t manifest_file_number_;
+
+  std::deque<ManifestWriter*> manifest_writers_;
 };
 
 }  // namespace titandb

--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -267,7 +267,7 @@ Status TitanDBImpl::OpenImpl(const std::vector<TitanCFDescriptor>& descs,
   // so new `BlobFileSet` here but not in constructor is to get a proper info
   // log.
   blob_file_set_.reset(
-      new BlobFileSet(db_options_, stats_.get(), &initialized_));
+      new BlobFileSet(db_options_, stats_.get(), &initialized_, &mutex_));
   // Setup options.
   db_options_.listeners.emplace_back(std::make_shared<BaseDbListener>(this));
   // Descriptors for actually open DB.

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -190,6 +190,7 @@ class TitanDBImpl : public TitanDB {
   friend class TitanGCStatsTest;
   friend class TitanCompactionFilterFactory;
   friend class TitanCompactionFilter;
+  friend class TableBuilderTest;
 
   Status OpenImpl(const std::vector<TitanCFDescriptor>& descs,
                   std::vector<ColumnFamilyHandle*>* handles);

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -191,6 +191,7 @@ class TitanDBImpl : public TitanDB {
   friend class TitanCompactionFilterFactory;
   friend class TitanCompactionFilter;
   friend class TableBuilderTest;
+  friend class TitanThreadSafetyTest;
 
   Status OpenImpl(const std::vector<TitanCFDescriptor>& descs,
                   std::vector<ColumnFamilyHandle*>* handles);

--- a/src/edit_collector.h
+++ b/src/edit_collector.h
@@ -241,7 +241,7 @@ class EditCollector {
   };
 
   Status status_{Status::OK()};
-  //
+
   bool sealed_{false};
   bool has_next_file_number_{false};
   uint64_t next_file_number_{0};

--- a/src/table_builder_test.cc
+++ b/src/table_builder_test.cc
@@ -168,9 +168,10 @@ class TableBuilderTest : public testing::Test {
     cf_moptions_ = MutableCFOptions(cf_options_);
     cf_ioptions_ = ImmutableCFOptions(cf_options_);
     ioptions_ = ImmutableOptions(db_ioptions_, cf_ioptions_);
-    blob_file_set_.reset(new BlobFileSet(db_options_, nullptr, nullptr));
-    std::map<uint32_t, TitanCFOptions> cfs{{0, cf_options_}};
     db_impl_.reset(new TitanDBImpl(db_options_, tmpdir_));
+    blob_file_set_.reset(
+        new BlobFileSet(db_options_, nullptr, nullptr, &db_impl_->mutex_));
+    std::map<uint32_t, TitanCFOptions> cfs{{0, cf_options_}};
     db_impl_->TEST_set_initialized(true);
     blob_file_set_->Open(cfs);
     blob_manager_.reset(new FileManager(db_options_, blob_file_set_.get()));

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -113,6 +113,7 @@ class TitanDBTest : public testing::Test {
   }
 
   Status LogAndApply(VersionEdit& edit) {
+    MutexLock l(&db_impl_->mutex_);
     return db_impl_->blob_file_set_->LogAndApply(edit);
   }
 


### PR DESCRIPTION
Holding mutex when syncing manifest may block other places for a while, which affects tail latency quite a lot.

This is based on #274, should merge that first