### PR TITLE
Fix possible delete blob file twice error

### DIFF
--- a/src/blob_file_set.cc
+++ b/src/blob_file_set.cc
@@ -337,10 +337,14 @@ Status BlobFileSet::DropColumnFamilies(
           TITAN_LOG_INFO(db_options_.info_log,
                          "Titan add obsolete file [%" PRIu64 "]",
                          file.second->file_number());
+          file.second->FileStateTransit(BlobFileMeta::FileEvent::kGCBegin);
           edit.DeleteBlobFile(file.first, obsolete_sequence);
         }
       }
       s = LogAndApply(edit);
+      for (auto& file : it->second->files_) {
+        file.second->FileStateTransit(BlobFileMeta::FileEvent::kGCCompleted);
+      }
       if (!s.ok()) return s;
     } else {
       TITAN_LOG_ERROR(db_options_.info_log, "column %u not found for drop\n",

--- a/src/blob_file_set.cc
+++ b/src/blob_file_set.cc
@@ -229,7 +229,7 @@ Status BlobFileSet::LogAndApply(VersionEdit& edit) {
   TEST_SYNC_POINT("BlobFileSet::LogAndApply::Begin");
   edit.SetNextFileNumber(next_file_number_.load());
 
-  EditCollector collector(db_options_.info_log.get(), false);
+  EditCollector collector(db_options_.info_log.get(), true);
   Status s = collector.AddEdit(edit);
   if (!s.ok()) return s;
   s = collector.Seal(*this);

--- a/src/blob_gc_job.cc
+++ b/src/blob_gc_job.cc
@@ -165,11 +165,6 @@ Status BlobGCJob::DoRunGC() {
   std::unique_ptr<BlobFileHandle> blob_file_handle;
   std::unique_ptr<BlobFileBuilder> blob_file_builder;
 
-  //  uint64_t drop_entry_num = 0;
-  //  uint64_t drop_entry_size = 0;
-  //  uint64_t total_entry_num = 0;
-  //  uint64_t total_entry_size = 0;
-
   uint64_t file_size = 0;
 
   std::string last_key;
@@ -409,6 +404,7 @@ Status BlobGCJob::Finish() {
   }
 
   if (s.ok() && !blob_gc_->GetColumnFamilyData()->IsDropped()) {
+    TEST_SYNC_POINT("BlobGCJob::Finish::BeforeDeleteInputBlobFiles");
     s = DeleteInputBlobFiles();
   }
   TEST_SYNC_POINT("BlobGCJob::Finish::AfterRewriteValidKeyToLSM");

--- a/src/blob_gc_job_test.cc
+++ b/src/blob_gc_job_test.cc
@@ -462,6 +462,55 @@ TEST_F(BlobGCJobTest, PurgeBlobs) {
   CheckBlobNumber(1);
 }
 
+TEST_F(BlobGCJobTest, GCWhileDeleteFilesInRange) {
+  NewDB();
+
+  for (int i = 0; i < MAX_KEY_NUM; i++) {
+    db_->Put(WriteOptions(), GenKey(i), GenValue(i));
+  }
+  Flush();
+  std::string result;
+  for (int i = 0; i < MAX_KEY_NUM; i++) {
+    db_->Delete(WriteOptions(), GenKey(i));
+  }
+  Flush();
+  CompactAll();
+
+  rocksdb::SyncPoint::GetInstance()->LoadDependency({
+      {"BlobGCJob::Finish::BeforeDeleteInputBlobFiles",
+       "BlobGCJobTest::GCWhileDeleteFilesInRange:Wait"},
+      {"BlobFileSet::LogAndApply::Wait",
+       "BlobGCJobTest::GCWhileDeleteFilesInRange:1"},
+      {"BlobGCJobTest::GCWhileDeleteFilesInRange:2",
+       "BlobFileSet::LogAndApply::AfterSyncTitanManifest"},
+  });
+  rocksdb::SyncPoint::GetInstance()->EnableProcessing();
+
+  rocksdb::port::Thread t1([&]() { RunGC(true); });
+  rocksdb::port::Thread t2([&]() {
+    TEST_SYNC_POINT("BlobGCJobTest::GCWhileDeleteFilesInRange:Wait");
+    RangePtr range(nullptr, nullptr);
+    ASSERT_OK(
+        db_->DeleteBlobFilesInRanges(db_->DefaultColumnFamily(), &range, 1));
+  });
+
+  // Wait until both `RunGC` and `DeleteBlobFilesInRanges` are processing in
+  // `LogAndApply`
+  TEST_SYNC_POINT("BlobGCJobTest::GCWhileDeleteFilesInRange:1");
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  TEST_SYNC_POINT("BlobGCJobTest::GCWhileDeleteFilesInRange:2");
+  t1.join();
+  t2.join();
+
+  Reopen();
+
+  TitanReadOptions opts;
+  auto* iter = db_->NewIterator(opts, db_->DefaultColumnFamily());
+  iter->SeekToFirst();
+  ASSERT_FALSE(iter->Valid());
+  delete iter;
+}
+
 TEST_F(BlobGCJobTest, DeleteFilesInRange) {
   NewDB();
 

--- a/src/blob_storage.cc
+++ b/src/blob_storage.cc
@@ -42,8 +42,10 @@ Status BlobStorage::GetBlobFilesInRanges(
          it != ((end != nullptr) ? blob_ranges_.upper_bound(*end)
                                  : blob_ranges_.end());
          it++) {
-      // The file is obsolete or being GCed, so just skip.
-      if (it->second->file_state() != BlobFileMeta::FileState::kNormal) {
+      // The file is obsolete or being processed(such as GC), for safety just
+      // skip.
+      if (it->second->file_state() != BlobFileMeta::FileState::kNormal &&
+          it->second->file_state() != BlobFileMeta::FileState::kToMerge) {
         continue;
       }
 

--- a/src/blob_storage.cc
+++ b/src/blob_storage.cc
@@ -26,9 +26,9 @@ Status BlobStorage::NewPrefetcher(uint64_t file_number,
                                     result);
 }
 
-Status BlobStorage::GetBlobFilesInRanges(const RangePtr* ranges, size_t n,
-                                         bool include_end,
-                                         std::vector<uint64_t>* files) {
+Status BlobStorage::GetBlobFilesInRanges(
+    const RangePtr* ranges, size_t n, bool include_end,
+    std::vector<std::shared_ptr<BlobFileMeta>>* files) {
   MutexLock l(&mutex_);
   for (size_t i = 0; i < n; i++) {
     const Slice* begin = ranges[i].start;
@@ -42,8 +42,11 @@ Status BlobStorage::GetBlobFilesInRanges(const RangePtr* ranges, size_t n,
          it != ((end != nullptr) ? blob_ranges_.upper_bound(*end)
                                  : blob_ranges_.end());
          it++) {
-      // Obsolete files are to be deleted, so just skip.
-      if (it->second->is_obsolete()) continue;
+      // The file is obsolete or being GCed, so just skip.
+      if (it->second->file_state() != BlobFileMeta::FileState::kNormal) {
+        continue;
+      }
+
       // The smallest and largest key of blob file meta of the old version are
       // empty, so skip.
       if (it->second->largest_key().empty() && end) continue;
@@ -51,7 +54,7 @@ Status BlobStorage::GetBlobFilesInRanges(const RangePtr* ranges, size_t n,
       if ((end == nullptr) ||
           (include_end && cmp->Compare(it->second->largest_key(), *end) <= 0) ||
           (!include_end && cmp->Compare(it->second->largest_key(), *end) < 0)) {
-        files->push_back(it->second->file_number());
+        files->push_back(it->second);
         if (!tmp.empty()) {
           tmp.append(" ");
         }

--- a/src/blob_storage.h
+++ b/src/blob_storage.h
@@ -73,8 +73,9 @@ class BlobStorage {
                        std::unique_ptr<BlobFilePrefetcher>* result);
 
   // Get all the blob files within the ranges.
-  Status GetBlobFilesInRanges(const RangePtr* ranges, size_t n,
-                              bool include_end, std::vector<uint64_t>* files);
+  Status GetBlobFilesInRanges(
+      const RangePtr* ranges, size_t n, bool include_end,
+      std::vector<std::shared_ptr<BlobFileMeta>>* files);
 
   // Finds the blob file meta for the specified file number. It is a
   // corruption if the file doesn't exist.

--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -65,6 +65,8 @@ class TitanDBImpl::FileManager : public BlobFileManager {
                                   std::unique_ptr<BlobFileHandle>>>& files)
       override {
     Status s;
+    if (files.empty()) return s;
+
     VersionEdit edit;
     edit.SetColumnFamilyID(cf_id);
     for (auto& file : files) {

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -1255,9 +1255,10 @@ TEST_F(TitanDBTest, BackgroundErrorTrigger) {
     Delete(i);
   }
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
-  SyncPoint::GetInstance()->SetCallBack("BlobFileSet::LogAndApply", [&](void*) {
-    mock_env->SetFilesystemActive(false, Status::IOError("Injected error"));
-  });
+  SyncPoint::GetInstance()->SetCallBack(
+      "BlobFileSet::LogAndApply::Begin", [&](void*) {
+        mock_env->SetFilesystemActive(false, Status::IOError("Injected error"));
+      });
   SyncPoint::GetInstance()->EnableProcessing();
   CallGC();
   mock_env->SetFilesystemActive(true);

--- a/src/version_test.cc
+++ b/src/version_test.cc
@@ -258,6 +258,7 @@ TEST_F(VersionTest, ObsoleteFiles) {
     auto add1_1_5 = AddBlobFilesEdit(1, 1, 5);
     MutexLock l(&mutex_);
     blob_file_set_->LogAndApply(add1_1_5);
+    blob_file_set_->GetBlobStorage(1).lock()->InitializeAllFiles();
   }
   std::vector<std::string> of;
   blob_file_set_->GetObsoleteFiles(&of, kMaxSequenceNumber);
@@ -331,6 +332,7 @@ TEST_F(VersionTest, DeleteBlobsInRange) {
   Slice end = Slice("80");
   RangePtr range(&begin, &end);
   auto blob = blob_file_set_->GetBlobStorage(1).lock();
+  blob->InitializeAllFiles();
 
   {
     MutexLock l(&mutex_);

--- a/src/version_test.cc
+++ b/src/version_test.cc
@@ -258,6 +258,7 @@ TEST_F(VersionTest, ObsoleteFiles) {
     auto add1_1_5 = AddBlobFilesEdit(1, 1, 5);
     MutexLock l(&mutex_);
     blob_file_set_->LogAndApply(add1_1_5);
+    blob_file_set_->GetBlobStorage(1).lock()->StartInitializeAllFiles();
     blob_file_set_->GetBlobStorage(1).lock()->InitializeAllFiles();
   }
   std::vector<std::string> of;
@@ -332,6 +333,7 @@ TEST_F(VersionTest, DeleteBlobsInRange) {
   Slice end = Slice("80");
   RangePtr range(&begin, &end);
   auto blob = blob_file_set_->GetBlobStorage(1).lock();
+  blob->StartInitializeAllFiles();
   blob->InitializeAllFiles();
 
   {

--- a/src/version_test.cc
+++ b/src/version_test.cc
@@ -82,7 +82,7 @@ class VersionTest : public testing::Test {
   }
 
   void BuildAndCheck(std::vector<VersionEdit> edits) {
-    EditCollector collector;
+    EditCollector collector(nullptr, true);
     for (auto& edit : edits) {
       ASSERT_OK(collector.AddEdit(edit));
     }
@@ -163,7 +163,7 @@ TEST_F(VersionTest, InvalidEdit) {
   // init state
   {
     auto add1_0_4 = AddBlobFilesEdit(1, 0, 4);
-    EditCollector collector;
+    EditCollector collector(nullptr, true);
     ASSERT_OK(collector.AddEdit(add1_0_4));
     ASSERT_OK(collector.Seal(*blob_file_set_.get()));
     ASSERT_OK(collector.Apply(*blob_file_set_.get()));
@@ -172,7 +172,7 @@ TEST_F(VersionTest, InvalidEdit) {
   // delete nonexistent blobs
   {
     auto del1_4_6 = DeleteBlobFilesEdit(1, 4, 6);
-    EditCollector collector;
+    EditCollector collector(nullptr, true);
     ASSERT_OK(collector.AddEdit(del1_4_6));
     ASSERT_NOK(collector.Seal(*blob_file_set_.get()));
     ASSERT_NOK(collector.Apply(*blob_file_set_.get()));
@@ -181,7 +181,7 @@ TEST_F(VersionTest, InvalidEdit) {
   // add already existing blobs
   {
     auto add1_1_3 = AddBlobFilesEdit(1, 1, 3);
-    EditCollector collector;
+    EditCollector collector(nullptr, true);
     ASSERT_OK(collector.AddEdit(add1_1_3));
     ASSERT_NOK(collector.Seal(*blob_file_set_.get()));
     ASSERT_NOK(collector.Apply(*blob_file_set_.get()));
@@ -191,7 +191,7 @@ TEST_F(VersionTest, InvalidEdit) {
   {
     auto add1_4_5_1 = AddBlobFilesEdit(1, 4, 5);
     auto add1_4_5_2 = AddBlobFilesEdit(1, 4, 5);
-    EditCollector collector;
+    EditCollector collector(nullptr, true);
     ASSERT_OK(collector.AddEdit(add1_4_5_1));
     ASSERT_NOK(collector.AddEdit(add1_4_5_2));
     ASSERT_NOK(collector.Seal(*blob_file_set_.get()));
@@ -202,7 +202,7 @@ TEST_F(VersionTest, InvalidEdit) {
   {
     auto del1_3_4_1 = DeleteBlobFilesEdit(1, 3, 4);
     auto del1_3_4_2 = DeleteBlobFilesEdit(1, 3, 4);
-    EditCollector collector;
+    EditCollector collector(nullptr, true);
     ASSERT_OK(collector.AddEdit(del1_3_4_1));
     ASSERT_NOK(collector.AddEdit(del1_3_4_2));
     ASSERT_NOK(collector.Seal(*blob_file_set_.get()));
@@ -322,7 +322,7 @@ TEST_F(VersionTest, DeleteBlobsInRange) {
                                                std::move(metas[i].second));
     edit.AddBlobFile(file);
   }
-  EditCollector collector;
+  EditCollector collector(nullptr, true);
   ASSERT_OK(collector.AddEdit(edit));
   ASSERT_OK(collector.Seal(*blob_file_set_.get()));
   ASSERT_OK(collector.Apply(*blob_file_set_.get()));

--- a/tools/manifest_dump.cc
+++ b/tools/manifest_dump.cc
@@ -60,7 +60,7 @@ int manifest_dump() {
   std::string scratch;
 
   // Loop through log records.
-  EditCollector edit_collector;
+  EditCollector edit_collector(stdout, true);
   while (log_reader.ReadRecord(&record, &scratch) && s.ok()) {
     VersionEdit edit;
     s = DecodeInto(record, &edit);

--- a/tools/manifest_dump.cc
+++ b/tools/manifest_dump.cc
@@ -60,7 +60,7 @@ int manifest_dump() {
   std::string scratch;
 
   // Loop through log records.
-  EditCollector edit_collector(stdout, true);
+  EditCollector edit_collector(nullptr, true);
   while (log_reader.ReadRecord(&record, &scratch) && s.ok()) {
     VersionEdit edit;
     s = DecodeInto(record, &edit);
@@ -70,7 +70,7 @@ int manifest_dump() {
       fprintf(stdout, "\n");
     }
     s = edit_collector.AddEdit(edit);
-    handle_error(s, "colllect version edit");
+    handle_error(s, "collect version edit");
   }
   if (!FLAGS_ignore_tail_err) {
     handle_error(s, "parse manifest record");


### PR DESCRIPTION
At start, it may encounter the error that blob file has been deleted twice
```
[server.rs:1916] ["failed to create kv engine: Storage Engine Status { code: IoError, sub_code: None, sev: NoError, state: 
\"Corruption: Blob file 49782 has been deleted twice\" }"]
```

It's introduced by #281. Previously, the `LogAndApply` was covered in the mutex as a whole critical area. With the lock optimization to avoid IO within the mutex, the `LogAndApply` itself is separated into different stages. There is a chance that both `DeleteBlobFilesInRanges` and `GC` select the same blob file and both pass `EditCollector::Seal` check, so the blob file can be deleted twice.

Here is a possible operation timing:
- GC chooses blob file 1 to rewrite it
- GC finish rewriting and begin to delete the input(blob file 1)
- GC triggers `LogAndApply` and pass the check of `EditCollector::Seal`
- GC unlocks the mutex to write edit record to manifest
- DeleteBlobFilesInRange is performed because the mutex is not held by GC now, then it chooses blob file 1 to delete
- DeleteBlobFilesInRange triggers `LogAndApply` and passes the check of `EditCollector::Seal` because GC is in writing manifest, still not apply the change to blob storage that blob file 1 is not obsolete now
- DeleteBlobFilesInRange unlocks the mutex and waits for GC to finish writing manifest
- GC finishes writing the manifest and locks the mutex to apply the change, now blob file 1 is marked as obsolete
- DeleteBlobFilesInRange finishes writing manifest and apply the change, blob file 1 is marked as obsolete again
- Titan restarts and finds the blob file 1 is deleted twice

The error is caused by Titan's paranoid check at the start, it could be simply recovered by ignoring the error. Then Titan would rewrite the manifest without the duplicated delete. And the data's correctness and integrity is still held. 

This PR fixes it by:
- Disable paranoid check by default
- In `DeleteBlobFilesInRange`, check the file state if it is marked by GC already, if then just skip it to avoid deleted twice.