### PR TITLE
Store blob storage ptr in column family handle to avoid mutex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,19 +177,19 @@ if (WITH_TITAN_TOOLS)
   add_definitions(-DGFLAGS)
 
   add_executable(titandb_stress tools/titandb_stress.cc)
-  target_include_directories(titandb_stress PRIVATE ${gflags_INCLUDE_DIR})
+  target_include_directories(titandb_stress PRIVATE ${GFLAGS_INCLUDE_DIR})
   target_link_libraries(titandb_stress ${TOOLS_LIBS})
 
   add_executable(titandb_bench tools/db_bench.cc tools/db_bench_tool.cc)
-  target_include_directories(titandb_bench PRIVATE ${gflags_INCLUDE_DIR})
+  target_include_directories(titandb_bench PRIVATE ${GFLAGS_INCLUDE_DIR})
   target_link_libraries(titandb_bench ${TOOLS_LIBS})
 
   add_executable(titan_manifest_dump tools/manifest_dump.cc)
-  target_include_directories(titan_manifest_dump PRIVATE ${gflags_INCLUDE_DIR})
+  target_include_directories(titan_manifest_dump PRIVATE ${GFLAGS_INCLUDE_DIR})
   target_link_libraries(titan_manifest_dump ${TOOLS_LIBS})
   
   add_executable(titan_blob_file_dump tools/blob_file_dump.cc)
-  target_include_directories(titan_blob_file_dump PRIVATE ${gflags_INCLUDE_DIR})
+  target_include_directories(titan_blob_file_dump PRIVATE ${GFLAGS_INCLUDE_DIR})
   target_link_libraries(titan_blob_file_dump ${TOOLS_LIBS})
 endif()
 

--- a/src/db.cc
+++ b/src/db.cc
@@ -15,8 +15,6 @@ Status TitanDB::Open(const TitanOptions& options, const std::string& dbname,
   Status s = TitanDB::Open(db_options, dbname, descs, &handles, db);
   if (s.ok()) {
     assert(handles.size() == 1);
-    // DBImpl is always holding the default handle.
-    delete handles[0];
   }
   return s;
 }

--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -777,8 +777,8 @@ Iterator* TitanDBImpl::NewIteratorImpl(
     std::shared_ptr<ManagedSnapshot> snapshot) {
   auto cfd = reinterpret_cast<ColumnFamilyHandleImpl*>(handle)->cfd();
 
-  auto storage = static_cast_with_check<TitanColumnFamilyHandle>(handle)
-                     ->GetBlobStorage();
+  auto storage =
+      static_cast_with_check<TitanColumnFamilyHandle>(handle)->GetBlobStorage();
 
   if (!storage) {
     TITAN_LOG_ERROR(db_options_.info_log,

--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -777,9 +777,8 @@ Iterator* TitanDBImpl::NewIteratorImpl(
     std::shared_ptr<ManagedSnapshot> snapshot) {
   auto cfd = reinterpret_cast<ColumnFamilyHandleImpl*>(handle)->cfd();
 
-  mutex_.Lock();
-  auto storage = blob_file_set_->GetBlobStorage(handle->GetID()).lock();
-  mutex_.Unlock();
+  auto storage = static_cast_with_check<TitanColumnFamilyHandle>(handle)
+                     ->GetBlobStorage();
 
   if (!storage) {
     TITAN_LOG_ERROR(db_options_.info_log,
@@ -982,7 +981,8 @@ Status TitanDBImpl::DeleteFilesInRanges(ColumnFamilyHandle* column_family,
   if (!s.ok()) return s;
 
   MutexLock l(&mutex_);
-  auto bs = blob_file_set_->GetBlobStorage(cf_id).lock();
+  auto bs = static_cast_with_check<TitanColumnFamilyHandle>(column_family)
+                ->GetBlobStorage();
   if (!bs) {
     // TODO: Should treat it as background error and make DB read-only.
     TITAN_LOG_ERROR(db_options_.info_log,

--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -335,10 +335,9 @@ Status TitanDBImpl::OpenImpl(const std::vector<TitanCFDescriptor>& descs,
     auto rocks_cf_handle =
         static_cast_with_check<rocksdb::ColumnFamilyHandleImpl>((*handles)[i]);
     auto titan_handle = new TitanColumnFamilyHandle(
-        *rocks_cf_handle,
+        rocks_cf_handle,
         blob_file_set_->GetBlobStorage(rocks_cf_handle->GetID()).lock());
     (*handles)[i] = titan_handle;
-    delete rocks_cf_handle;
     if ((*handles)[i]->GetName() == kDefaultColumnFamilyName) {
       default_cf_handle_ = titan_handle;
     }
@@ -372,6 +371,7 @@ Status TitanDBImpl::Close() {
   if (db_) {
     if (default_cf_handle_ != nullptr) {
       delete default_cf_handle_;
+      default_cf_handle_ = nullptr;
     }
     s = db_->Close();
     delete db_;
@@ -489,10 +489,9 @@ Status TitanDBImpl::CreateColumnFamilies(
             static_cast_with_check<rocksdb::ColumnFamilyHandleImpl>(
                 (*handles)[i]);
         auto titan_handle = new TitanColumnFamilyHandle(
-            *rocks_cf_handle,
+            rocks_cf_handle,
             blob_file_set_->GetBlobStorage(rocks_cf_handle->GetID()).lock());
         (*handles)[i] = titan_handle;
-        delete rocks_cf_handle;
       }
     }
   }

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -27,16 +27,13 @@ class TitanCompactionFilter;
 
 class TitanColumnFamilyHandle : public rocksdb::ColumnFamilyHandleImpl {
  public:
-  TitanColumnFamilyHandle(
-      rocksdb::ColumnFamilyHandleImpl* rocks_cf_handle,
-      std::shared_ptr<BlobStorage> blob_storage)
+  TitanColumnFamilyHandle(rocksdb::ColumnFamilyHandleImpl* rocks_cf_handle,
+                          std::shared_ptr<BlobStorage> blob_storage)
       : rocksdb::ColumnFamilyHandleImpl(*rocks_cf_handle),
         rocks_cf_handle_(rocks_cf_handle),
         blob_storage_(blob_storage) {}
 
-  ~TitanColumnFamilyHandle() {
-    delete rocks_cf_handle_;
-  }
+  ~TitanColumnFamilyHandle() { delete rocks_cf_handle_; }
 
   std::shared_ptr<BlobStorage> GetBlobStorage() { return blob_storage_; }
 

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -31,14 +31,14 @@ class TitanColumnFamilyHandle : public rocksdb::ColumnFamilyHandleImpl {
       const rocksdb::ColumnFamilyHandleImpl& rocks_cf_handle,
       std::shared_ptr<BlobStorage> blob_storage)
       : rocksdb::ColumnFamilyHandleImpl(rocks_cf_handle),
-        blob_storage(blob_storage) {}
+        blob_storage_(blob_storage) {}
 
   ~TitanColumnFamilyHandle() {}
 
-  std::shared_ptr<BlobStorage> GetBlobStorage() { return blob_storage; }
+  std::shared_ptr<BlobStorage> GetBlobStorage() { return blob_storage_; }
 
  private:
-  std::shared_ptr<BlobStorage> blob_storage;
+  std::shared_ptr<BlobStorage> blob_storage_;
 };
 
 class TitanDBImpl : public TitanDB {

--- a/src/titan_checkpoint_test.cc
+++ b/src/titan_checkpoint_test.cc
@@ -139,7 +139,7 @@ class CheckpointTest : public testing::Test {
 
   void Close() {
     for (auto h : handles_) {
-      delete h;
+      db_->DestroyColumnFamilyHandle(h);
     }
     handles_.clear();
     delete db_;
@@ -452,7 +452,7 @@ TEST_F(CheckpointTest, CheckpointCF) {
   ASSERT_OK(snapshotDB->Get(roptions, cphandles[6], "six", &result));
   ASSERT_EQ(large_value_2, result);
   for (auto h : cphandles) {
-    delete h;
+    snapshotDB->DestroyColumnFamilyHandle(h);
   }
   cphandles.clear();
   delete snapshotDB;
@@ -518,7 +518,7 @@ TEST_F(CheckpointTest, CheckpointCFNoFlush) {
   ASSERT_OK(snapshotDB->Get(roptions, cphandles[3], "three", &result));
   ASSERT_EQ(large_value_1, result);
   for (auto h : cphandles) {
-    delete h;
+    snapshotDB->DestroyColumnFamilyHandle(h);
   }
   cphandles.clear();
   delete snapshotDB;
@@ -690,7 +690,7 @@ TEST_F(CheckpointTest, GCWhileCheckpointing) {
   ASSERT_OK(snapshotDB->Get(roptions, cphandles[2], "two", &result));
   ASSERT_EQ(large_value_1, result);
   for (auto h : cphandles) {
-    delete h;
+    snapshotDB->DestroyColumnFamilyHandle(h);
   }
   cphandles.clear();
   delete snapshotDB;

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -355,21 +355,8 @@ TEST_F(TitanDBTest, Open) {
         background_job_started = true;
         assert(false);
       });
-  SyncPoint::GetInstance()->SetCallBack(
-      "TitanDBImpl::OpenImpl:BeforeOpenBlobFileSet", [&](void* arg) {
-        checked_before_blob_file_set = true;
-        TitanDBImpl* db = reinterpret_cast<TitanDBImpl*>(arg);
-        // Try to trigger flush and compaction. Listeners should not be call.
-        ASSERT_OK(db->Put(WriteOptions(), "k1", "v1"));
-        ASSERT_OK(db->Flush(FlushOptions()));
-        ASSERT_OK(db->Put(WriteOptions(), "k1", "v2"));
-        ASSERT_OK(db->Put(WriteOptions(), "k2", "v3"));
-        ASSERT_OK(db->Flush(FlushOptions()));
-        ASSERT_OK(db->CompactRange(CompactRangeOptions(), nullptr, nullptr));
-      });
   SyncPoint::GetInstance()->EnableProcessing();
   Open();
-  ASSERT_TRUE(checked_before_blob_file_set.load());
   ASSERT_FALSE(background_job_started.load());
 }
 


### PR DESCRIPTION
Ref #294

Store a shared ptr of `BlobStorage` in `ColumnFamilyHandle`, so that, while reading, Titan does not need to lock and fetch it every time.