### PR TITLE
Not setting total order seek

### DIFF
--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -703,12 +703,10 @@ Status TitanDBImpl::GetImpl(const ReadOptions& options,
 std::vector<Status> TitanDBImpl::MultiGet(
     const ReadOptions& options, const std::vector<ColumnFamilyHandle*>& handles,
     const std::vector<Slice>& keys, std::vector<std::string>* values) {
-  auto options_copy = options;
-  options_copy.total_order_seek = true;
-  if (options_copy.snapshot) {
-    return MultiGetImpl(options_copy, handles, keys, values);
+  if (options.snapshot) {
+    return MultiGetImpl(options, handles, keys, values);
   }
-  ReadOptions ro(options_copy);
+  ReadOptions ro(options);
   ManagedSnapshot snapshot(this);
   ro.snapshot = snapshot.snapshot();
   return MultiGetImpl(ro, handles, keys, values);
@@ -733,13 +731,11 @@ std::vector<Status> TitanDBImpl::MultiGetImpl(
 
 Iterator* TitanDBImpl::NewIterator(const TitanReadOptions& options,
                                    ColumnFamilyHandle* handle) {
-  TitanReadOptions options_copy = options;
-  options_copy.total_order_seek = true;
   std::shared_ptr<ManagedSnapshot> snapshot;
-  if (options_copy.snapshot) {
-    return NewIteratorImpl(options_copy, handle, snapshot);
+  if (options.snapshot) {
+    return NewIteratorImpl(options, handle, snapshot);
   }
-  TitanReadOptions ro(options_copy);
+  TitanReadOptions ro(options);
   snapshot.reset(new ManagedSnapshot(this));
   ro.snapshot = snapshot->snapshot();
   return NewIteratorImpl(ro, handle, snapshot);
@@ -774,7 +770,6 @@ Status TitanDBImpl::NewIterators(
     const std::vector<ColumnFamilyHandle*>& handles,
     std::vector<Iterator*>* iterators) {
   TitanReadOptions ro(options);
-  ro.total_order_seek = true;
   std::shared_ptr<ManagedSnapshot> snapshot;
   if (!ro.snapshot) {
     snapshot.reset(new ManagedSnapshot(this));


### PR DESCRIPTION
Close #296 
Setting total_order_seek doesn't make sense here. Theoretically, it doesn't affect Titan correctness no matter how to iterate. 

Without setting it, upper caller can utilize prefix seek to improve scan performance.