### PR TITLE
New a seperated default column family handle 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT ROCKSDB_GIT_REPO)
 endif()
 
 if (NOT ROCKSDB_GIT_BRANCH)
-  set(ROCKSDB_GIT_BRANCH "6.29.tikv") # should newer than commit de47e8ece9abf001af74a9e60f66b9c8494240e1
+  set(ROCKSDB_GIT_BRANCH "6.29.tikv") # should at least or newer than commit dcf2f8d56092285381be2acbf8f04b8aeeb7ad79
 endif()
 
 if (NOT DEFINED ROCKSDB_DIR)

--- a/src/db.cc
+++ b/src/db.cc
@@ -15,6 +15,8 @@ Status TitanDB::Open(const TitanOptions& options, const std::string& dbname,
   Status s = TitanDB::Open(db_options, dbname, descs, &handles, db);
   if (s.ok()) {
     assert(handles.size() == 1);
+    // DBImpl is always holding the default handle.
+    delete handles[0];
   }
   return s;
 }

--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -569,6 +569,7 @@ Status TitanDBImpl::DestroyColumnFamilyHandle(
   }
 
   auto cf_id = column_family->GetID();
+  auto cf_name = column_family->GetName();
   if (column_family == default_cf_handle_) {
     return Status::InvalidArgument(
         "Default column family handle is not destroyable.");

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -32,8 +32,8 @@ class TitanColumnFamilyHandle : public rocksdb::ColumnFamilyHandleImpl {
                           bool owned = true)
       : rocksdb::ColumnFamilyHandleImpl(*rocks_cf_handle),
         rocks_cf_handle_(rocks_cf_handle),
-        blob_storage_(blob_storage),
-        owned_(owned) {}
+        owned_(owned),
+        blob_storage_(blob_storage) {}
 
   ~TitanColumnFamilyHandle() {
     if (owned_) delete rocks_cf_handle_;

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -28,12 +28,16 @@ class TitanCompactionFilter;
 class TitanColumnFamilyHandle : public rocksdb::ColumnFamilyHandleImpl {
  public:
   TitanColumnFamilyHandle(rocksdb::ColumnFamilyHandleImpl* rocks_cf_handle,
-                          std::shared_ptr<BlobStorage> blob_storage)
+                          std::shared_ptr<BlobStorage> blob_storage,
+                          bool owned = true)
       : rocksdb::ColumnFamilyHandleImpl(*rocks_cf_handle),
         rocks_cf_handle_(rocks_cf_handle),
-        blob_storage_(blob_storage) {}
+        blob_storage_(blob_storage),
+        owned_(owned) {}
 
-  ~TitanColumnFamilyHandle() { delete rocks_cf_handle_; }
+  ~TitanColumnFamilyHandle() {
+    if (owned_) delete rocks_cf_handle_;
+  }
 
   std::shared_ptr<BlobStorage> GetBlobStorage() { return blob_storage_; }
 
@@ -43,6 +47,10 @@ class TitanColumnFamilyHandle : public rocksdb::ColumnFamilyHandleImpl {
   // uses the pointer to the rocksdb::ColumnFamilyHandleImpl, we can't delete
   // it until the TitanColumnFamilyHandle is deleted.
   rocksdb::ColumnFamilyHandleImpl* rocks_cf_handle_;
+  // Whether it owns the rocksdb::ColumnFamilyHandleImpl*, if it owns, it delete
+  // the handle when dropped
+  bool owned_;
+
   std::shared_ptr<BlobStorage> blob_storage_;
 };
 
@@ -326,7 +334,7 @@ class TitanDBImpl : public TitanDB {
   TitanDBOptions db_options_;
   std::unique_ptr<Directory> directory_;
 
-  ColumnFamilyHandle* default_cf_handle_;
+  ColumnFamilyHandle* default_cf_handle_{nullptr};
 
   std::atomic<bool> initialized_{false};
 


### PR DESCRIPTION
To make the behavior consistent with rocksdb, new a separate handle for default column family, so default column family handle is always available even if the caller deletes the default column family handle.