### PR TITLE
Fix truncated file name in log

### DIFF
--- a/src/titan_logging.h
+++ b/src/titan_logging.h
@@ -20,12 +20,12 @@
 #define TITAN_LOG_STRINGIFY(x) #x
 #define TITAN_LOG_TOSTRING(x) TITAN_LOG_STRINGIFY(x)
 #define TITAN_LOG_PREPEND_FILE_LINE(FMT) \
-  ("[%s:" TITAN_LOG_TOSTRING(__LINE__) "] " FMT)
+  ("[titan/%s:" TITAN_LOG_TOSTRING(__LINE__) "] " FMT)
 
 inline const char* TitanLogShorterFileName(const char* file) {
-  // 15 is the length of "titan_logging.h".
+  // 16 is the length of "titan_logging.h".
   // If the name of this file changed, please change this number, too.
-  return file + (sizeof(__FILE__) > 15 ? sizeof(__FILE__) - 15 : 0);
+  return file + (sizeof(__FILE__) > 16 ? sizeof(__FILE__) - 16 : 0);
 }
 
 // Don't inclide file/line info in HEADER level


### PR DESCRIPTION
The file name of titan log is not intact
![bae62de2-9ad9-4dea-b785-8fdfcb176d8e](https://github.com/tikv/titan/assets/13497871/4311b5c4-9c8e-4752-aa17-0e7ff6597d77)

This PR does:
- Fix the wrong truncation
- Add a leading `titan/` to the file name to make it easier to distinguish with rocksdb logs
