### PR TITLE
Fix small file can't be gced in fallback mode

### DIFF
--- a/src/blob_storage.cc
+++ b/src/blob_storage.cc
@@ -243,7 +243,8 @@ void BlobStorage::ComputeGCScore() {
       // for the small file or file with gc mark (usually the file that just
       // recovered) we want gc these file but more hope to gc other file with
       // more invalid data
-      score = cf_options_.blob_file_discardable_ratio;
+      score = std::max(cf_options_.blob_file_discardable_ratio,
+                       file.second->GetDiscardableRatio());
     } else {
       score = file.second->GetDiscardableRatio();
     }

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -2,7 +2,6 @@
 #include <unordered_map>
 
 #include "db/db_impl/db_impl.h"
-#include "util/stderr_logger.h"
 #include "file/filename.h"
 #include "monitoring/statistics.h"
 #include "options/cf_options.h"

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -2,6 +2,7 @@
 #include <unordered_map>
 
 #include "db/db_impl/db_impl.h"
+#include "util/stderr_logger.h"
 #include "file/filename.h"
 #include "monitoring/statistics.h"
 #include "options/cf_options.h"
@@ -38,7 +39,6 @@ class TitanDBTest : public testing::Test {
     options_.create_if_missing = true;
     options_.min_blob_size = 32;
     options_.min_gc_batch_size = 1;
-    options_.merge_small_file_threshold = 0;
     options_.disable_background_gc = true;
     options_.blob_file_compression = CompressionType::kLZ4Compression;
     options_.statistics = CreateDBStatistics();
@@ -1073,6 +1073,7 @@ TEST_F(TitanDBTest, SetOptions) {
 
 TEST_F(TitanDBTest, BlobRunModeBasic) {
   options_.disable_background_gc = true;
+  options_.merge_small_file_threshold = 0;
   options_.disable_auto_compactions = true;
   Open();
 
@@ -1197,8 +1198,7 @@ TEST_F(TitanDBTest, FallbackModeEncounterMissingBlobFile) {
 
 TEST_F(TitanDBTest, GCInFallbackMode) {
   options_.disable_background_gc = true;
-  options_.blob_file_discardable_ratio = 0.01;
-  options_.min_blob_size = true;
+  options_.min_blob_size = 0;
   Open();
   ASSERT_OK(db_->Put(WriteOptions(), "foo", "v1"));
   ASSERT_OK(db_->Put(WriteOptions(), "bar", "v1"));


### PR DESCRIPTION
In fallback mode, only files with 100% discardable ratio, namely gc score of 1.0, would be dropped. But for small files, we deem its gc score as `blob_file_discardable_ratio`. If `blob_file_discardable_ratio` is not 1.0, small files would never be dropped.