### PR TITLE
Add block size for blob file

### DIFF
--- a/include/titan/options.h
+++ b/include/titan/options.h
@@ -161,6 +161,18 @@ struct TitanCFOptions : public ColumnFamilyOptions {
   // Default: false
   bool skip_value_in_compaction_filter{false};
 
+  // The size of each block in blob file. 0 means not using block-based mode,
+  // blob entries are stored continuously. While non-zero value means using
+  // block-based mode, blob entries are stored in blocks, and each block stores
+  // exactkt one blob entry, if the last block is not full, it will be filled
+  // with zeros. This is particularly useful when punch hole GC is enabled, as
+  // it can punch hole on block granularity and blob files are still
+  // self-explanatory after holes are created (imagine there is no alignment
+  // requirement for blob entries and Titan has to distinguish between real
+  // data's 0s and 0s created by punch holes).
+  uint64_t block_size{4096};
+  bool enable_punch_hole_gc{false};
+
   TitanCFOptions() = default;
   explicit TitanCFOptions(const ColumnFamilyOptions& options)
       : ColumnFamilyOptions(options) {}
@@ -205,6 +217,9 @@ struct ImmutableTitanCFOptions {
   bool level_merge;
 
   bool skip_value_in_compaction_filter;
+
+  uint64_t block_size;
+  bool enable_punch_hole_gc;
 };
 
 struct MutableTitanCFOptions {

--- a/include/titan/options.h
+++ b/include/titan/options.h
@@ -164,7 +164,7 @@ struct TitanCFOptions : public ColumnFamilyOptions {
   // The size of each block in blob file. 0 means not using block-based mode,
   // blob entries are stored continuously. While non-zero value means using
   // block-based mode, blob entries are stored in blocks, and each block stores
-  // exactkt one blob entry, if the last block is not full, it will be filled
+  // exactly one blob entry, if the last block is not full, it will be filled
   // with zeros. This is particularly useful when punch hole GC is enabled, as
   // it can punch hole on block granularity and blob files are still
   // self-explanatory after holes are created (imagine there is no alignment

--- a/src/blob_file_builder.h
+++ b/src/blob_file_builder.h
@@ -123,6 +123,7 @@ class BlobFileBuilder {
   void WriteCompressionDictBlock(MetaIndexBuilder* meta_index_builder);
   void FlushSampleRecords(OutContexts* out_ctx);
   void WriteEncoderData(BlobHandle* handle);
+  void FillBlockWithPad();
 
   TitanCFOptions cf_options_;
   WritableFileWriter* file_;
@@ -135,6 +136,8 @@ class BlobFileBuilder {
   std::vector<std::string> sample_records_;
   uint64_t sample_str_len_ = 0;
   std::unique_ptr<CompressionDict> compression_dict_;
+
+  uint64_t block_size_ = 0;
 
   OutContexts cached_contexts_;
 

--- a/src/blob_file_builder.h
+++ b/src/blob_file_builder.h
@@ -69,7 +69,7 @@ class BlobFileBuilder {
   // caller to sync and close the file after calling Finish().
   BlobFileBuilder(const TitanDBOptions& db_options,
                   const TitanCFOptions& cf_options, WritableFileWriter* file,
-                  uint32_t blob_file_version = BlobFileHeader::kVersion2);
+                  uint32_t blob_file_version = BlobFileHeader::kVersion3);
 
   // Tries to add the record to the file
   // Notice:

--- a/src/blob_file_iterator.cc
+++ b/src/blob_file_iterator.cc
@@ -21,11 +21,11 @@ BlobFileIterator::~BlobFileIterator() {}
 
 bool BlobFileIterator::Init() {
   Slice slice;
-  char header_buf[BlobFileHeader::kMaxEncodedLength];
+  char header_buf[BlobFileHeader::kV3EncodedLength];
   // With for_compaction=true, rate_limiter is enabled. Since BlobFileIterator
   // is only used for GC, we always set for_compaction to true.
   status_ =
-      file_->Read(IOOptions(), 0, BlobFileHeader::kMaxEncodedLength, &slice,
+      file_->Read(IOOptions(), 0, BlobFileHeader::kV3EncodedLength, &slice,
                   header_buf, nullptr /*aligned_buf*/, true /*for_compaction*/);
   if (!status_.ok()) {
     return false;
@@ -74,13 +74,13 @@ bool BlobFileIterator::Init() {
 
   block_size_ = blob_file_header.block_size;
 
-  assert(end_of_blob_record_ > BlobFileHeader::kMinEncodedLength);
+  assert(end_of_blob_record_ > BlobFileHeader::kV1EncodedLength);
   init_ = true;
   return true;
 }
 
 uint64_t BlobFileIterator::AdjustOffsetToNextBlockHead() {
-  if (block_size_ == 0) return;
+  if (block_size_ == 0) return 0;
   uint64_t block_offset = iterate_offset_ % block_size_;
   if (block_offset != 0) {
     uint64_t shift = block_size_ - block_offset;

--- a/src/blob_file_iterator.cc
+++ b/src/blob_file_iterator.cc
@@ -72,15 +72,31 @@ bool BlobFileIterator::Init() {
                             BlockBasedTable::kBlockTrailerSize);
   }
 
+  block_size_ = blob_file_header.block_size;
+
   assert(end_of_blob_record_ > BlobFileHeader::kMinEncodedLength);
   init_ = true;
   return true;
+}
+
+uint64_t BlobFileIterator::AdjustOffsetToNextBlockHead() {
+  if (block_size_ == 0) return;
+  uint64_t block_offset = iterate_offset_ % block_size_;
+  if (block_offset != 0) {
+    uint64_t shift = block_size_ - block_offset;
+    iterate_offset_ += shift;
+    return shift;
+  }
+  return 0;
 }
 
 void BlobFileIterator::SeekToFirst() {
   if (!init_ && !Init()) return;
   status_ = Status::OK();
   iterate_offset_ = header_size_;
+  if (block_size_ != 0) {
+    AdjustOffsetToNextBlockHead();
+  }
   PrefetchAndGet();
 }
 
@@ -109,7 +125,7 @@ void BlobFileIterator::IterateForPrev(uint64_t offset) {
   uint64_t total_length = 0;
   FixedSlice<kRecordHeaderSize> header_buffer;
   iterate_offset_ = header_size_;
-  for (; iterate_offset_ < offset; iterate_offset_ += total_length) {
+  while (iterate_offset_ < offset) {
     // With for_compaction=true, rate_limiter is enabled. Since
     // BlobFileIterator is only used for GC, we always set for_compaction to
     // true.
@@ -120,6 +136,10 @@ void BlobFileIterator::IterateForPrev(uint64_t offset) {
     status_ = decoder_.DecodeHeader(&header_buffer);
     if (!status_.ok()) return;
     total_length = kRecordHeaderSize + decoder_.GetRecordSize();
+    iterate_offset_ += total_length;
+    if (block_size_ != 0) {
+      total_length += AdjustOffsetToNextBlockHead();
+    }
   }
 
   if (iterate_offset_ > offset) iterate_offset_ -= total_length;
@@ -155,6 +175,7 @@ void BlobFileIterator::GetBlobRecord() {
   cur_record_offset_ = iterate_offset_;
   cur_record_size_ = kRecordHeaderSize + record_size;
   iterate_offset_ += cur_record_size_;
+  AdjustOffsetToNextBlockHead();
   valid_ = true;
 }
 

--- a/src/blob_file_iterator.h
+++ b/src/blob_file_iterator.h
@@ -70,6 +70,7 @@ class BlobFileIterator {
   uint64_t cur_record_offset_;
   uint64_t cur_record_size_;
   uint64_t header_size_;
+  uint64_t block_size_;
 
   uint64_t readahead_begin_offset_{0};
   uint64_t readahead_end_offset_{0};
@@ -77,6 +78,7 @@ class BlobFileIterator {
 
   void PrefetchAndGet();
   void GetBlobRecord();
+  uint64_t AdjustOffsetToNextBlockHead();
 };
 
 class BlobFileMergeIterator {

--- a/src/blob_file_iterator_test.cc
+++ b/src/blob_file_iterator_test.cc
@@ -272,6 +272,14 @@ TEST_F(BlobFileIteratorTest, IteratorWithBlocks) {
   }
 
   FinishBuilder(contexts);
+  uint64_t file_size = 0;
+  ASSERT_OK(env_->GetFileSize(file_name_, &file_size));
+  // 1000 records, each record is more than 4096 bytes (including key and
+  // value), plus a header block and a footer block, so the total number of
+  // blocks should be 1000 * 2 + 2, with the last block not fully filled.
+  ASSERT_EQ(file_size / 4096, 1000 * 2 + 1);
+  // The last block is not fully filled.
+  ASSERT_NE(file_size % 4096, 0);
 
   NewBlobFileIterator();
 

--- a/src/blob_file_reader.cc
+++ b/src/blob_file_reader.cc
@@ -113,8 +113,8 @@ Status BlobFileReader::Open(const TitanCFOptions& options,
 
 Status BlobFileReader::ReadHeader(std::unique_ptr<RandomAccessFileReader>& file,
                                   BlobFileHeader* header) {
-  FixedSlice<BlobFileHeader::kMaxEncodedLength> buffer;
-  Status s = file->Read(IOOptions(), 0, BlobFileHeader::kMaxEncodedLength,
+  FixedSlice<BlobFileHeader::kV3EncodedLength> buffer;
+  Status s = file->Read(IOOptions(), 0, BlobFileHeader::kV3EncodedLength,
                         &buffer, buffer.get(), nullptr /*aligned_buf*/);
   if (!s.ok()) return s;
 

--- a/src/blob_format.cc
+++ b/src/blob_format.cc
@@ -172,7 +172,7 @@ Status BlobFileMeta::DecodeFromV2(Slice* src) {
   return Status::OK();
 }
 
-Status BlobFileMeta::DecodeFromV3(Slice* src) {
+Status BlobFileMeta::DecodeFrom(Slice* src) {
   if (!GetVarint64(src, &file_number_) || !GetVarint64(src, &file_size_) ||
       !GetVarint64(src, &file_entries_) || !GetVarint32(src, &file_level_) ||
       !GetVarint64(src, &block_size_)) {

--- a/src/blob_format.cc
+++ b/src/blob_format.cc
@@ -315,7 +315,7 @@ Status BlobFileHeader::DecodeFrom(Slice* src) {
         "Blob file header magic number missing or mismatched.");
   }
   if (!GetFixed32(src, &version) ||
-      (version != kVersion1 && version != kVersion2)) {
+      (version != kVersion1 && version != kVersion2 && version != kVersion3)) {
     return Status::Corruption("Blob file header version missing or invalid.");
   }
   if (version >= BlobFileHeader::kVersion2) {

--- a/src/blob_format.h
+++ b/src/blob_format.h
@@ -35,7 +35,7 @@ namespace titandb {
 //    | Fixed32 | Fixed32 |    char     |
 //    +---------+---------+-------------+
 //
-const uint64_t kBlobMaxHeaderSize = 12;
+const uint64_t kBlobMaxHeaderSize = 20;
 const uint64_t kRecordHeaderSize = 9;
 const uint64_t kBlobFooterSize = BlockHandle::kMaxEncodedLength + 8 + 4;
 

--- a/src/blob_format.h
+++ b/src/blob_format.h
@@ -227,8 +227,8 @@ class BlobFileMeta {
 
   BlobFileMeta(uint64_t _file_number, uint64_t _file_size,
                uint64_t _file_entries, uint32_t _file_level,
-               uint64_t _block_size, const std::string& _smallest_key,
-               const std::string& _largest_key)
+               const std::string& _smallest_key,
+               const std::string& _largest_key, uint64_t _block_size = 0)
       : file_number_(_file_number),
         file_size_(_file_size),
         file_entries_(_file_entries),
@@ -242,7 +242,7 @@ class BlobFileMeta {
   void EncodeTo(std::string* dst) const;
   Status DecodeFromV1(Slice* src);
   Status DecodeFromV2(Slice* src);
-  Status DecodeFromV3(Slice* src);
+  Status DecodeFrom(Slice* src);
 
   uint64_t file_number() const { return file_number_; }
   uint64_t file_size() const { return file_size_; }
@@ -353,11 +353,16 @@ struct BlobFileHeader {
   }
 
   uint64_t size() const {
-    return version == BlobFileHeader::kVersion3
-               ? BlobFileHeader::kV3EncodedLength
-               : version == BlobFileHeader::kVersion2
-               ? ? BlobFileHeader::kV2EncodedLength
-                 : BlobFileHeader::kV1EncodedLength;
+    switch (version) {
+      case BlobFileHeader::kVersion3:
+        return BlobFileHeader::kV3EncodedLength;
+      case BlobFileHeader::kVersion2:
+        return BlobFileHeader::kV2EncodedLength;
+      case BlobFileHeader::kVersion1:
+        return BlobFileHeader::kV1EncodedLength;
+      default:
+        return 0;
+    }
   }
 
   void EncodeTo(std::string* dst) const;

--- a/src/blob_format.h
+++ b/src/blob_format.h
@@ -227,20 +227,22 @@ class BlobFileMeta {
 
   BlobFileMeta(uint64_t _file_number, uint64_t _file_size,
                uint64_t _file_entries, uint32_t _file_level,
-               const std::string& _smallest_key,
+               uint64_t _block_size, const std::string& _smallest_key,
                const std::string& _largest_key)
       : file_number_(_file_number),
         file_size_(_file_size),
         file_entries_(_file_entries),
         file_level_(_file_level),
+        block_size_(_block_size),
         smallest_key_(_smallest_key),
         largest_key_(_largest_key) {}
 
   friend bool operator==(const BlobFileMeta& lhs, const BlobFileMeta& rhs);
 
   void EncodeTo(std::string* dst) const;
-  Status DecodeFrom(Slice* src);
-  Status DecodeFromLegacy(Slice* src);
+  Status DecodeFromV1(Slice* src);
+  Status DecodeFromV2(Slice* src);
+  Status DecodeFromV3(Slice* src);
 
   uint64_t file_number() const { return file_number_; }
   uint64_t file_size() const { return file_size_; }
@@ -283,6 +285,7 @@ class BlobFileMeta {
   uint64_t file_entries_;
   // Target level of compaction/flush which generates this blob file
   uint32_t file_level_;
+  uint64_t block_size_{0};
   // Empty `smallest_key_` and `largest_key_` means smallest key is unknown,
   // and can only happen when the file is from legacy version.
   std::string smallest_key_;
@@ -327,18 +330,22 @@ struct BlobFileHeader {
   static const uint32_t kHeaderMagicNumber = 0x2be0a614ul;
   static const uint32_t kVersion1 = 1;
   static const uint32_t kVersion2 = 2;
+  static const uint32_t kVersion3 = 3;
 
-  static const uint64_t kMinEncodedLength = 4 + 4;
-  static const uint64_t kMaxEncodedLength = 4 + 4 + 4;
+  static const uint64_t kV1EncodedLength = 4 + 4;
+  static const uint64_t kV2EncodedLength = 4 + 4 + 4;
+  static const uint64_t kV3EncodedLength = 4 + 4 + 4 + 8;
 
   // Flags:
   static const uint32_t kHasUncompressionDictionary = 1 << 0;
 
-  uint32_t version = kVersion2;
+  uint32_t version = kVersion3;
   uint32_t flags = 0;
+  uint64_t block_size = 0;
 
   static Status ValidateVersion(uint32_t ver) {
-    if (ver != BlobFileHeader::kVersion1 && ver != BlobFileHeader::kVersion2) {
+    if (ver != BlobFileHeader::kVersion1 && ver != BlobFileHeader::kVersion2 &&
+        ver != BlobFileHeader::kVersion3) {
       return Status::InvalidArgument("unrecognized blob file version " +
                                      ToString(ver));
     }
@@ -346,9 +353,11 @@ struct BlobFileHeader {
   }
 
   uint64_t size() const {
-    return version == BlobFileHeader::kVersion1
-               ? BlobFileHeader::kMinEncodedLength
-               : BlobFileHeader::kMaxEncodedLength;
+    return version == BlobFileHeader::kVersion3
+               ? BlobFileHeader::kV3EncodedLength
+               : version == BlobFileHeader::kVersion2
+               ? ? BlobFileHeader::kV2EncodedLength
+                 : BlobFileHeader::kV1EncodedLength;
   }
 
   void EncodeTo(std::string* dst) const;

--- a/src/blob_format_test.cc
+++ b/src/blob_format_test.cc
@@ -36,7 +36,7 @@ TEST(BlobFormatTest, BlobIndex) {
 }
 
 TEST(BlobFormatTest, BlobFileMeta) {
-  BlobFileMeta input(2, 3, 0, 0, "0", "9");
+  BlobFileMeta input(2, 3, 0, 0, 0, "0", "9");
   CheckCodec(input);
 }
 

--- a/src/blob_format_test.cc
+++ b/src/blob_format_test.cc
@@ -36,7 +36,7 @@ TEST(BlobFormatTest, BlobIndex) {
 }
 
 TEST(BlobFormatTest, BlobFileMeta) {
-  BlobFileMeta input(2, 3, 0, 0, 0, "0", "9");
+  BlobFileMeta input(2, 3, 0, 0, "0", "9");
   CheckCodec(input);
 }
 

--- a/src/blob_gc_job.cc
+++ b/src/blob_gc_job.cc
@@ -433,7 +433,8 @@ Status BlobGCJob::InstallOutputBlobFiles() {
 
     auto file = std::make_shared<BlobFileMeta>(
         builder.first->GetNumber(), builder.first->GetFile()->GetFileSize(), 0,
-        0, builder.second->GetSmallestKey(), builder.second->GetLargestKey());
+        0, builder.second->GetSmallestKey(), builder.second->GetLargestKey(),
+        /*block_size=*/0);
     file->set_live_data_size(builder.second->live_data_size());
     file->FileStateTransit(BlobFileMeta::FileEvent::kGCOutput);
     RecordInHistogram(statistics(stats_), TITAN_GC_OUTPUT_FILE_SIZE,

--- a/src/options.cc
+++ b/src/options.cc
@@ -43,7 +43,9 @@ TitanCFOptions::TitanCFOptions(const ColumnFamilyOptions& cf_opts,
       merge_small_file_threshold(immutable_opts.merge_small_file_threshold),
       blob_run_mode(mutable_opts.blob_run_mode),
       skip_value_in_compaction_filter(
-          immutable_opts.skip_value_in_compaction_filter) {}
+          immutable_opts.skip_value_in_compaction_filter),
+      block_size(immutable_opts.block_size),
+      enable_punch_hole_gc(immutable_opts.enable_punch_hole_gc) {}
 
 void TitanCFOptions::Dump(Logger* logger) const {
   TITAN_LOG_HEADER(logger,

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -238,7 +238,8 @@ void TitanTableBuilder::FinishBlobFile() {
       std::shared_ptr<BlobFileMeta> file = std::make_shared<BlobFileMeta>(
           blob_handle_->GetNumber(), blob_handle_->GetFile()->GetFileSize(),
           blob_builder_->NumEntries(), target_level_,
-          blob_builder_->GetSmallestKey(), blob_builder_->GetLargestKey());
+          blob_builder_->GetSmallestKey(), blob_builder_->GetLargestKey(),
+          /*block_size=*/0);
       file->set_live_data_size(blob_builder_->live_data_size());
       file->FileStateTransit(BlobFileMeta::FileEvent::kFlushOrCompactionOutput);
       finished_blobs_.push_back({file, std::move(blob_handle_)});

--- a/src/version_edit.cc
+++ b/src/version_edit.cc
@@ -69,7 +69,7 @@ Status VersionEdit::DecodeFrom(Slice* src) {
         break;
       case kAddedBlobFileV3:
         blob_file = std::make_shared<BlobFileMeta>();
-        s = blob_file->DecodeFromV3(src);
+        s = blob_file->DecodeFrom(src);
         if (s.ok()) {
           AddBlobFile(blob_file);
         } else {

--- a/src/version_edit.cc
+++ b/src/version_edit.cc
@@ -13,7 +13,7 @@ void VersionEdit::EncodeTo(std::string* dst) const {
   PutVarint32Varint32(dst, kColumnFamilyID, column_family_id_);
 
   for (auto& file : added_files_) {
-    PutVarint32(dst, kAddedBlobFileV2);
+    PutVarint32(dst, kAddedBlobFileV3);
     file->EncodeTo(dst);
   }
   for (auto& file : deleted_files_) {
@@ -51,7 +51,7 @@ Status VersionEdit::DecodeFrom(Slice* src) {
       // for compatibility issue
       case kAddedBlobFile:
         blob_file = std::make_shared<BlobFileMeta>();
-        s = blob_file->DecodeFromLegacy(src);
+        s = blob_file->DecodeFromV1(src);
         if (s.ok()) {
           AddBlobFile(blob_file);
         } else {
@@ -60,7 +60,16 @@ Status VersionEdit::DecodeFrom(Slice* src) {
         break;
       case kAddedBlobFileV2:
         blob_file = std::make_shared<BlobFileMeta>();
-        s = blob_file->DecodeFrom(src);
+        s = blob_file->DecodeFromV2(src);
+        if (s.ok()) {
+          AddBlobFile(blob_file);
+        } else {
+          error = s.ToString().c_str();
+        }
+        break;
+      case kAddedBlobFileV3:
+        blob_file = std::make_shared<BlobFileMeta>();
+        s = blob_file->DecodeFromV3(src);
         if (s.ok()) {
           AddBlobFile(blob_file);
         } else {

--- a/src/version_edit.h
+++ b/src/version_edit.h
@@ -18,7 +18,8 @@ enum Tag {
   kDeletedBlobFile = 12,  // Deprecated, leave here for backward compatibility
   kAddedBlobFileV2 = 13,  // Comparing to kAddedBlobFile, it newly includes
                           // smallest_key and largest_key of blob file
-  kAddedBlobFileV3 = 14,
+  kAddedBlobFileV3 = 14,  // Comparing to kAddedBlobFileV2, it newly includes
+                          // block_size of blob file
 };
 
 class VersionEdit {

--- a/src/version_edit.h
+++ b/src/version_edit.h
@@ -18,6 +18,7 @@ enum Tag {
   kDeletedBlobFile = 12,  // Deprecated, leave here for backward compatibility
   kAddedBlobFileV2 = 13,  // Comparing to kAddedBlobFile, it newly includes
                           // smallest_key and largest_key of blob file
+  kAddedBlobFileV3 = 14,
 };
 
 class VersionEdit {


### PR DESCRIPTION
This PR introduces "blocks" into Titan. This is part of the "punch hole GC" project.
We need to align blobs with blocks to be able to locate next available blobs (or iterating the blob files) when there are holes in the file.