### PR TITLE
Propagate for_compaction from compaction filter

### DIFF
--- a/src/blob_file_cache.cc
+++ b/src/blob_file_cache.cc
@@ -27,13 +27,13 @@ BlobFileCache::BlobFileCache(const TitanDBOptions& db_options,
 
 Status BlobFileCache::Get(const ReadOptions& options, uint64_t file_number,
                           const BlobHandle& handle, BlobRecord* record,
-                          OwnedSlice* buffer) {
+                          OwnedSlice* buffer, bool for_compaction) {
   Cache::Handle* cache_handle = nullptr;
   Status s = GetBlobFileReaderHandle(file_number, &cache_handle);
   if (!s.ok()) return s;
 
   auto reader = reinterpret_cast<BlobFileReader*>(cache_->Value(cache_handle));
-  s = reader->Get(options, handle, record, buffer);
+  s = reader->Get(options, handle, record, buffer, for_compaction);
   cache_->Release(cache_handle);
   return s;
 }

--- a/src/blob_file_cache.h
+++ b/src/blob_file_cache.h
@@ -22,7 +22,12 @@ class BlobFileCache {
   // bytes. The provided buffer is used to store the record data, so
   // the buffer must be valid when the record is used.
   Status Get(const ReadOptions& options, uint64_t file_number,
-             const BlobHandle& handle, BlobRecord* record, OwnedSlice* buffer);
+             const BlobHandle& handle, BlobRecord* record, OwnedSlice* buffer) {
+    return Get(options, file_number, handle, record, buffer, false);
+  }
+  Status Get(const ReadOptions& options, uint64_t file_number,
+             const BlobHandle& handle, BlobRecord* record, OwnedSlice* buffer,
+             bool for_compaction);
 
   // Creates a prefetcher for the specified file number.
   Status NewPrefetcher(uint64_t file_number,

--- a/src/blob_file_cache.h
+++ b/src/blob_file_cache.h
@@ -22,12 +22,8 @@ class BlobFileCache {
   // bytes. The provided buffer is used to store the record data, so
   // the buffer must be valid when the record is used.
   Status Get(const ReadOptions& options, uint64_t file_number,
-             const BlobHandle& handle, BlobRecord* record, OwnedSlice* buffer) {
-    return Get(options, file_number, handle, record, buffer, false);
-  }
-  Status Get(const ReadOptions& options, uint64_t file_number,
              const BlobHandle& handle, BlobRecord* record, OwnedSlice* buffer,
-             bool for_compaction);
+             bool for_compaction = false);
 
   // Creates a prefetcher for the specified file number.
   Status NewPrefetcher(uint64_t file_number,

--- a/src/blob_file_reader.cc
+++ b/src/blob_file_reader.cc
@@ -130,13 +130,13 @@ BlobFileReader::BlobFileReader(const TitanCFOptions& options,
 
 Status BlobFileReader::Get(const ReadOptions& _options,
                            const BlobHandle& handle, BlobRecord* record,
-                           OwnedSlice* buffer) {
+                           OwnedSlice* buffer, bool for_compaction) {
   TEST_SYNC_POINT("BlobFileReader::Get");
   Slice blob;
   CacheAllocationPtr ubuf =
       AllocateBlock(handle.size, options_.memory_allocator());
   Status s = file_->Read(IOOptions(), handle.offset, handle.size, &blob,
-                         ubuf.get(), nullptr /*aligned_buf*/);
+                         ubuf.get(), nullptr /*aligned_buf*/, for_compaction);
   if (!s.ok()) {
     return s;
   }

--- a/src/blob_file_reader.h
+++ b/src/blob_file_reader.h
@@ -28,12 +28,8 @@ class BlobFileReader {
   // of the record is stored in the value slice underlying, so the value slice
   // must be valid when the record is used.
   Status Get(const ReadOptions& options, const BlobHandle& handle,
-             BlobRecord* record, OwnedSlice* buffer) {
-    return Get(options, handle, record, buffer, false);
-  }
-
-  Status Get(const ReadOptions& options, const BlobHandle& handle,
-             BlobRecord* record, OwnedSlice* buffer, bool for_compaction);
+             BlobRecord* record, OwnedSlice* buffer,
+             bool for_compaction = false);
 
  private:
   friend class BlobFilePrefetcher;

--- a/src/blob_file_reader.h
+++ b/src/blob_file_reader.h
@@ -28,7 +28,12 @@ class BlobFileReader {
   // of the record is stored in the value slice underlying, so the value slice
   // must be valid when the record is used.
   Status Get(const ReadOptions& options, const BlobHandle& handle,
-             BlobRecord* record, OwnedSlice* buffer);
+             BlobRecord* record, OwnedSlice* buffer) {
+    return Get(options, handle, record, buffer, false);
+  }
+
+  Status Get(const ReadOptions& options, const BlobHandle& handle,
+             BlobRecord* record, OwnedSlice* buffer, bool for_compaction);
 
  private:
   friend class BlobFilePrefetcher;

--- a/src/blob_gc_job_test.cc
+++ b/src/blob_gc_job_test.cc
@@ -538,6 +538,10 @@ TEST_F(BlobGCJobTest, DeleteFilesInRange) {
   ASSERT_OK(db_->Delete(WriteOptions(), GenKey(8)));
   ASSERT_OK(db_->Delete(WriteOptions(), GenKey(9)));
   CompactAll();
+  ASSERT_TRUE(db_->GetProperty("rocksdb.num-files-at-level1", &value));
+  ASSERT_EQ(value, "0");
+  ASSERT_TRUE(db_->GetProperty("rocksdb.num-files-at-level2", &value));
+  ASSERT_EQ(value, "0");
 
   ASSERT_TRUE(db_->GetProperty("rocksdb.num-files-at-level0", &value));
   ASSERT_EQ(value, "0");

--- a/src/blob_storage.cc
+++ b/src/blob_storage.cc
@@ -35,7 +35,8 @@ Status BlobStorage::TryGetBlobCache(const std::string& cache_key,
 }
 
 Status BlobStorage::Get(const ReadOptions& options, const BlobIndex& index,
-                        BlobRecord* record, PinnableSlice* value) {
+                        BlobRecord* record, PinnableSlice* value,
+                        bool for_compaction) {
   std::string cache_key;
 
   if (blob_cache_) {
@@ -48,7 +49,7 @@ Status BlobStorage::Get(const ReadOptions& options, const BlobIndex& index,
 
   OwnedSlice blob;
   Status s = file_cache_->Get(options, index.file_number, index.blob_handle,
-                              record, &blob);
+                              record, &blob, for_compaction);
   if (!s.ok()) {
     return s;
   }

--- a/src/blob_storage.h
+++ b/src/blob_storage.h
@@ -61,7 +61,11 @@ class BlobStorage {
   // buffer is used to store the record data, so the buffer must be
   // valid when the record is used.
   Status Get(const ReadOptions& options, const BlobIndex& index,
-             BlobRecord* record, PinnableSlice* value);
+             BlobRecord* record, PinnableSlice* value) {
+    return Get(options, index, record, value, false);
+  }
+  Status Get(const ReadOptions& options, const BlobIndex& index,
+             BlobRecord* record, PinnableSlice* value, bool for_compaction);
 
   // Gets the blob record pointed by the blob index by blob cache.
   // The provided buffer is used to store the record data, so the buffer must be
@@ -193,9 +197,9 @@ class BlobStorage {
    public:
     // The default constructor is not supposed to be used.
     // It is only to make std::multimap can compile.
-    InternalComparator() : comparator_(nullptr){};
+    InternalComparator() : comparator_(nullptr) {};
     explicit InternalComparator(const Comparator* comparator)
-        : comparator_(comparator){};
+        : comparator_(comparator) {};
     bool operator()(const Slice& key1, const Slice& key2) const {
       assert(comparator_ != nullptr);
       return comparator_->Compare(key1, key2) < 0;

--- a/src/blob_storage.h
+++ b/src/blob_storage.h
@@ -61,11 +61,8 @@ class BlobStorage {
   // buffer is used to store the record data, so the buffer must be
   // valid when the record is used.
   Status Get(const ReadOptions& options, const BlobIndex& index,
-             BlobRecord* record, PinnableSlice* value) {
-    return Get(options, index, record, value, false);
-  }
-  Status Get(const ReadOptions& options, const BlobIndex& index,
-             BlobRecord* record, PinnableSlice* value, bool for_compaction);
+             BlobRecord* record, PinnableSlice* value,
+             bool for_compaction = false);
 
   // Gets the blob record pointed by the blob index by blob cache.
   // The provided buffer is used to store the record data, so the buffer must be
@@ -197,9 +194,9 @@ class BlobStorage {
    public:
     // The default constructor is not supposed to be used.
     // It is only to make std::multimap can compile.
-    InternalComparator() : comparator_(nullptr) {};
+    InternalComparator() : comparator_(nullptr){};
     explicit InternalComparator(const Comparator* comparator)
-        : comparator_(comparator) {};
+        : comparator_(comparator){};
     bool operator()(const Slice& key1, const Slice& key2) const {
       assert(comparator_ != nullptr);
       return comparator_->Compare(key1, key2) < 0;

--- a/src/compaction_filter.h
+++ b/src/compaction_filter.h
@@ -88,7 +88,7 @@ class TitanCompactionFilter final : public CompactionFilter {
     BlobRecord record;
     PinnableSlice buffer;
     ReadOptions read_options;
-    s = blob_storage_->Get(read_options, blob_index, &record, &buffer);
+    s = blob_storage_->Get(read_options, blob_index, &record, &buffer, true);
 
     if (s.IsCorruption()) {
       // Could be cause by blob file beinged GC-ed, or real corruption.


### PR DESCRIPTION
Solving https://github.com/tikv/titan/issues/324.

This fix only works for 6.29 RocksDB. Once we upgrade RocksDB I will propose a different fix which, instead of propagating `for_compaction`, propagate `rate_limit_priority`.