### PR TITLE
Fix close hang

### DIFF
--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -412,8 +412,8 @@ Status TitanDBImpl::CloseImpl() {
 
   {
     MutexLock l(&mutex_);
-    // `bg_gc_scheduled_` should be 0 after `JoinAllThreads`, double check here.
-    while (bg_gc_scheduled_ > 0) {
+    // `bg_gc_running_` should be 0 after `JoinAllThreads`, double check here.
+    while (bg_gc_running_ > 0) {
       bg_cv_.Wait();
     }
   }


### PR DESCRIPTION
The original code may cause the program to hang forever. A GC job might get scheduled before closing, but does not get executed since [`JoinAllThreads()` discards all jobs that did not start running](https://github.com/tikv/rocksdb/blob/e25544481ba8fab12a4bc426181a4a890c95cecb/util/threadpool_imp.h#L29-L32).  

Fix it by checking `bg_gc_running_` to achieve the same goal but correctly.

I found it accidentally while running unit tests on my desktop Arch Linux, not sure why it worked fine in the CI.