### PR TITLE
Add raw blob size to blob index

### DIFF
--- a/src/blob_file_builder.cc
+++ b/src/blob_file_builder.cc
@@ -164,6 +164,7 @@ void BlobFileBuilder::FlushSampleRecords(OutContexts* out_ctx) {
 void BlobFileBuilder::WriteEncoderData(BlobHandle* handle) {
   handle->offset = file_->GetFileSize();
   handle->size = encoder_.GetEncodedSize();
+  handle->raw_size = encoder_.GetRawSize();
   live_data_size_ += handle->size;
 
   status_ = file_->Append(encoder_.GetHeader());

--- a/src/blob_format.cc
+++ b/src/blob_format.cc
@@ -45,7 +45,7 @@ void BlobEncoder::EncodeRecord(const BlobRecord& record) {
 // EncodeSlice compresses the record and prepares the header. The compressed
 // record is stored in `record_`.
 void BlobEncoder::EncodeSlice(const Slice& record) {
-  raw_size_ = record.size(); // record the uncompressed size
+  raw_size_ = record.size();  // record the uncompressed size
 
   compressed_buffer_.clear();
   CompressionType compression;
@@ -134,8 +134,7 @@ void BlobIndex::EncodeTo(std::string* dst) const {
 
 Status BlobIndex::DecodeFrom(Slice* src) {
   unsigned char type;
-  if (!GetChar(src, &type) || type != kBlobRecord ||
-      !GetVarint64(src, &file_number)) {
+  if (!GetChar(src, &type) || !GetVarint64(src, &file_number)) {
     return Status::Corruption("BlobIndex");
   }
   Status s = blob_handle.DecodeFrom(src);

--- a/src/blob_format.cc
+++ b/src/blob_format.cc
@@ -42,7 +42,11 @@ void BlobEncoder::EncodeRecord(const BlobRecord& record) {
   EncodeSlice(record_buffer_);
 }
 
+// EncodeSlice compresses the record and prepares the header. The compressed
+// record is stored in `record_`.
 void BlobEncoder::EncodeSlice(const Slice& record) {
+  raw_size_ = record.size(); // record the uncompressed size
+
   compressed_buffer_.clear();
   CompressionType compression;
   record_ =
@@ -99,11 +103,21 @@ Status BlobDecoder::DecodeRecord(Slice* src, BlobRecord* record,
 void BlobHandle::EncodeTo(std::string* dst) const {
   PutVarint64(dst, offset);
   PutVarint64(dst, size);
+  PutVarint64(dst, raw_size);
 }
 
 Status BlobHandle::DecodeFrom(Slice* src) {
   if (!GetVarint64(src, &offset) || !GetVarint64(src, &size)) {
     return Status::Corruption("BlobHandle");
+  }
+
+  // Optional: raw_size (may not exist in older versions)
+  if (!src->empty()) {
+    if (!GetVarint64(src, &raw_size)) {
+      return Status::Corruption("BlobHandle (raw_size)");
+    }
+  } else {
+    raw_size = size;  // assume no compression
   }
   return Status::OK();
 }

--- a/src/blob_format.h
+++ b/src/blob_format.h
@@ -135,16 +135,16 @@ class BlobDecoder {
 
 // Format of blob handle (not fixed size):
 //
-//    +----------+----------+------------+
-//    |  offset  |   size   |  raw_size  |
-//    +----------+----------+------------+
-//    | Varint64 | Varint64 |  Varint64  |
-//    +----------+----------+------------+
+//    +----------+----------+-----------------------+
+//    |  offset  |   size   |  raw_size (optional)  |
+//    +----------+----------+-----------------------+
+//    | Varint64 | Varint64 |      Varint64         |
+//    +----------+----------+-----------------------+
 //
 struct BlobHandle {
   uint64_t offset{0};
   uint64_t size{0};
-  uint64_t raw_size{0}; // Uncompressed data size
+  uint64_t raw_size{0};  // Uncompressed data size
 
   void EncodeTo(std::string* dst) const;
   Status DecodeFrom(Slice* src);
@@ -154,11 +154,12 @@ struct BlobHandle {
 
 // Format of blob index (not fixed size):
 //
-//    +------+-------------+---------------------------------------------------------+
-//    | type | file number |                    blob handle                          |
-//    +------+-------------+---------------------------------------------------------+
-//    | char |  Varint64   | Varint64(offsest) + Varint64(size) + Varint64(raw_size) |
-//    +------+-------------+---------------------------------------------------------+
+//    +------+-------------+---------------------------------------------------+
+//    | type | file number |                    blob handle                    |
+//    +------+-------------+---------------------------------------------------+
+//    | char |  Varint64   | Varint64(offsest) + Varint64(size)                |
+//    |      |             |                   + (optional) Varint64(raw_size) |
+//    +------+-------------+---------------------------------------------------+
 //
 // It is stored in LSM-Tree as the value of key, then Titan can use this blob
 // index to locate actual value from blob file.

--- a/src/blob_format.h
+++ b/src/blob_format.h
@@ -92,10 +92,12 @@ class BlobEncoder {
   Slice GetRecord() const { return record_; }
 
   size_t GetEncodedSize() const { return sizeof(header_) + record_.size(); }
+  size_t GetRawSize() const { return raw_size_; }
 
  private:
   char header_[kRecordHeaderSize];
   Slice record_;
+  uint64_t raw_size_{0};
   std::string record_buffer_;
   std::string compressed_buffer_;
   CompressionOptions compression_opt_;
@@ -133,15 +135,16 @@ class BlobDecoder {
 
 // Format of blob handle (not fixed size):
 //
-//    +----------+----------+
-//    |  offset  |   size   |
-//    +----------+----------+
-//    | Varint64 | Varint64 |
-//    +----------+----------+
+//    +----------+----------+------------+
+//    |  offset  |   size   |  raw_size  |
+//    +----------+----------+------------+
+//    | Varint64 | Varint64 |  Varint64  |
+//    +----------+----------+------------+
 //
 struct BlobHandle {
   uint64_t offset{0};
   uint64_t size{0};
+  uint64_t raw_size{0}; // Uncompressed data size
 
   void EncodeTo(std::string* dst) const;
   Status DecodeFrom(Slice* src);
@@ -151,11 +154,11 @@ struct BlobHandle {
 
 // Format of blob index (not fixed size):
 //
-//    +------+-------------+------------------------------------+
-//    | type | file number |            blob handle             |
-//    +------+-------------+------------------------------------+
-//    | char |  Varint64   | Varint64(offsest) + Varint64(size) |
-//    +------+-------------+------------------------------------+
+//    +------+-------------+---------------------------------------------------------+
+//    | type | file number |                    blob handle                          |
+//    +------+-------------+---------------------------------------------------------+
+//    | char |  Varint64   | Varint64(offsest) + Varint64(size) + Varint64(raw_size) |
+//    +------+-------------+---------------------------------------------------------+
 //
 // It is stored in LSM-Tree as the value of key, then Titan can use this blob
 // index to locate actual value from blob file.


### PR DESCRIPTION
This commit records the uncompressed size of blob values in `BlobIndex`. After this, TiKV can use this information to more accurately estimate region size, especially when the compression ratio is high.