### PR TITLE
Revert "Add raw blob size to blob index (#334)"

### DIFF
--- a/src/blob_file_builder.cc
+++ b/src/blob_file_builder.cc
@@ -164,7 +164,6 @@ void BlobFileBuilder::FlushSampleRecords(OutContexts* out_ctx) {
 void BlobFileBuilder::WriteEncoderData(BlobHandle* handle) {
   handle->offset = file_->GetFileSize();
   handle->size = encoder_.GetEncodedSize();
-  handle->raw_size = encoder_.GetRawSize();
   live_data_size_ += handle->size;
 
   status_ = file_->Append(encoder_.GetHeader());

--- a/src/blob_format.h
+++ b/src/blob_format.h
@@ -92,12 +92,10 @@ class BlobEncoder {
   Slice GetRecord() const { return record_; }
 
   size_t GetEncodedSize() const { return sizeof(header_) + record_.size(); }
-  size_t GetRawSize() const { return raw_size_; }
 
  private:
   char header_[kRecordHeaderSize];
   Slice record_;
-  uint64_t raw_size_{0};
   std::string record_buffer_;
   std::string compressed_buffer_;
   CompressionOptions compression_opt_;
@@ -135,16 +133,15 @@ class BlobDecoder {
 
 // Format of blob handle (not fixed size):
 //
-//    +----------+----------+-----------------------+
-//    |  offset  |   size   |  raw_size (optional)  |
-//    +----------+----------+-----------------------+
-//    | Varint64 | Varint64 |      Varint64         |
-//    +----------+----------+-----------------------+
+//    +----------+----------+
+//    |  offset  |   size   |
+//    +----------+----------+
+//    | Varint64 | Varint64 |
+//    +----------+----------+
 //
 struct BlobHandle {
   uint64_t offset{0};
   uint64_t size{0};
-  uint64_t raw_size{0};  // Uncompressed data size
 
   void EncodeTo(std::string* dst) const;
   Status DecodeFrom(Slice* src);
@@ -154,12 +151,11 @@ struct BlobHandle {
 
 // Format of blob index (not fixed size):
 //
-//    +------+-------------+---------------------------------------------------+
-//    | type | file number |                    blob handle                    |
-//    +------+-------------+---------------------------------------------------+
-//    | char |  Varint64   | Varint64(offsest) + Varint64(size)                |
-//    |      |             |                   + (optional) Varint64(raw_size) |
-//    +------+-------------+---------------------------------------------------+
+//    +------+-------------+------------------------------------+
+//    | type | file number |            blob handle             |
+//    +------+-------------+------------------------------------+
+//    | char |  Varint64   | Varint64(offsest) + Varint64(size) |
+//    +------+-------------+------------------------------------+
 //
 // It is stored in LSM-Tree as the value of key, then Titan can use this blob
 // index to locate actual value from blob file.


### PR DESCRIPTION
This reverts commit f5c7e39e1e98c4a5e2bf538fa812687a1fd0a6b3 because the data format of blob index can't be changed while still supporting rollbacks.

See https://github.com/tikv/titan/pull/334#issuecomment-3026813148